### PR TITLE
Add settings and service method for determining completion-by-viewing delay.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,12 @@ Unreleased
 ~~~~~~~~~~
 * Nothing
 
-[0.0.6] - 2018-02-13
+[0.0.7] - 2018-02-15
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Add settings and service method for determining completion-by-viewing delay.
+
+  [0.0.6] - 2018-02-13
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Add the additional completion logic into the service and models from edx-platform

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/services.py
+++ b/completion/services.py
@@ -4,6 +4,8 @@ Runtime service for communicating completion information to the xblock system.
 
 from __future__ import unicode_literals
 
+from django.conf import settings
+
 from .models import BlockCompletion
 from . import waffle
 
@@ -99,3 +101,10 @@ class CompletionService(object):
             if completions[child_location] < 1.0:
                 return False
         return True
+
+    def get_completion_by_viewing_delay_ms(self):
+        """
+        Do not mark blocks complete-by-viewing until they have been visible for
+        the returned amount of time, in milliseconds.  Defaults to 5000.
+        """
+        return getattr(settings, 'COMPLETION_BY_VIEWING_DELAY_MS', 5000)

--- a/completion/settings/common.py
+++ b/completion/settings/common.py
@@ -36,4 +36,8 @@ def plugin_settings(settings):  # pylint: disable=unused-argument
     Defines completion-specific settings when app is used as a plugin to edx-platform.
     See: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    pass
+    # Once a complete-by-viewing (e.g. HTML) block has been visible on-screen for this many ms, mark it complete
+    settings.COMPLETION_BY_VIEWING_DELAY_MS = 5000
+    # Once a user has watched this percentage of a video, mark it as complete:
+    # (0.0 = 0%, 1.0 = 100%)
+    settings.COMPLETION_VIDEO_COMPLETE_PERCENTAGE = 0.95

--- a/completion/tests/test_services.py
+++ b/completion/tests/test_services.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import ddt
 from django.test import TestCase
+from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from ..models import BlockCompletion
@@ -78,3 +79,17 @@ class CompletionServiceTestCase(CompletionSetUpMixin, TestCase):
     def test_enabled_honors_waffle_switch(self, enabled):
         with self.override_completion_switch(enabled):
             self.assertEqual(self.completion_service.completion_tracking_enabled(), enabled)
+
+
+@ddt.ddt
+class CompletionDelayTestCase(CompletionSetUpMixin, TestCase):
+    """
+    Test that the completion-by-viewing delay is properly passed in from
+    the project settings.
+    """
+
+    @ddt.data(1, 1000, 0)
+    def test_get_completion_by_viewing_delay_ms(self, delay):
+        service = CompletionService(self.user, self.course_key)
+        with override_settings(COMPLETION_BY_VIEWING_DELAY_MS=delay):
+            self.assertEqual(service.get_completion_by_viewing_delay_ms(), delay)


### PR DESCRIPTION
Ported from OSPR-2093

**Description:**
This ports the `lms/djangoapps/completion` portions of https://github.com/edx/edx-platform/pull/16833/files into the completion library.  Once this is released, we can update the version of edx-completion in edx-platform, then fix and merge the above PR.

**JIRA:**
https://openedx.atlassian.net/browse/OSPR-2093

**Dependencies:**
https://github.com/edx/edx-platform/pull/16833/files

**Reviewers:**
- [x] Simon
- [ ] @jcdyer

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)