### PR TITLE
Add model method for "Last User Completed Block"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Alex Dusenbery <adusenbery@edx.org>
 Simon Chen <schen@edx.org>
+Gregory Martin <greg@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+* Add query method for all completions by course
+
+[0.0.8] - 2018-03-01
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 * Nothing
 
 [0.0.7] - 2018-02-15

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,3 +10,4 @@ py==1.5.2                 # via pytest
 pytest-cov==2.5.1
 pytest==3.3.2             # via pytest-cov, pytest-django
 six==1.11.0               # via pytest
+freezegun==0.3.8


### PR DESCRIPTION
## [EDUCATOR-2296](https://openedx.atlassian.net/browse/EDUCATOR-2296)

### Description
Add model method for superlative “last completed block” - for site awareness include *every* last completed block by course, for later sorting in business layer.
Django ORM proved insufficient (builtins are not compatible with our current RDS instance) for getting this specific query, so raw SQL was used.

Related to (and blocking):
https://github.com/edx/edx-platform/pull/17467

### Testing
- [ ] Unit tests

### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @schenedx 

FYI: @edx/educator-neem

### Post-review
- [ ] Rebase and squash commits


