### PR TITLE
Fix Django 2.0 incompatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
   include:
   - python: 3.5
     env: TOXENV=quality
+  - python: 3.5
+    env: TOXENV=django20
 cache:
 - pip
 before_install:

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.0.9'
+__version__ = '0.0.10'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/migrations/0001_initial.py
+++ b/completion/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
                 ('block_key', UsageKeyField(max_length=255)),
                 ('block_type', models.CharField(max_length=64)),
                 ('completion', models.FloatField(validators=[validate_percent])),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
         migrations.AlterUniqueTogether(

--- a/completion/models.py
+++ b/completion/models.py
@@ -162,7 +162,7 @@ class BlockCompletion(TimeStampedModel, models.Model):
     complete, and 0.0 indicates that the block is incomplete.
     """
     id = BigAutoField(primary_key=True)  # pylint: disable=invalid-name
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
     course_key = CourseKeyField(max_length=255)
 
     # note: this usage key may not have the run filled in for

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35}-django{18,111}
+envlist = {py27,py35}-django{18,111},py35-django20
 
 [doc8]
 max-line-length = 120
@@ -25,6 +25,7 @@ norecursedirs = .* docs requirements
 deps =
     django18: Django>=1.8,<1.9
     django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/dev.txt
 commands =


### PR DESCRIPTION
Never too early to prepare for the future.  Fixed based on this recommendation

    django.utils.deprecation.RemovedInDjango20Warning: on_delete will be a required arg for 
    ForeignKey in Django 2.0. Set it to models.CASCADE on models and in existing migrations if you
    want to maintain the current default behavior. 
    See https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.on_delete

This was causing open-craft/openedx-completion-aggregator#4 tests to fail once I added completion as a depenency, even on django 1.11.  Probably some configuration was causing deprecation warnings to get promoted to errors. :woman_shrugging: 

Review: @ciuin, @iloveagent57 