### PR TITLE
Correct the latest_blocks_completed_all_courses query.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,11 @@ Unreleased
 ~~~~~~~~~~
 * Add query method for all completions by course
 
-[0.0.10] - 2018-03-20
+[0.1.0] - 2018-03-20
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fixes https://openedx.atlassian.net/browse/EDUCATOR-2540
+
+[0.0.11] - 2018-03-20
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Added "subsection-completion/{username}/{course_key}/{subsection_id}" API

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.0.11'
+__version__ = '0.1.0'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/models.py
+++ b/completion/models.py
@@ -214,10 +214,28 @@ class BlockCompletion(TimeStampedModel, models.Model):
 
         latest_completions_by_course = cls.objects.raw(
             '''
-            SELECT id, course_key, block_key, max(modified) as latest
-            FROM completion_blockcompletion
-            WHERE user_id=%s
-            GROUP BY course_key;
+            SELECT
+                cbc.id AS id,
+                cbc.course_key AS course_key,
+                cbc.block_key AS block_key,
+                cbc.modified AS modified
+            FROM
+                completion_blockcompletion cbc
+            JOIN (
+                SELECT
+                     course_key,
+                     MAX(modified) AS modified
+                FROM
+                     completion_blockcompletion
+                WHERE
+                     user_id = %s
+                GROUP BY
+                     course_key
+            ) latest
+            ON
+                cbc.course_key = latest.course_key AND
+                cbc.modified = latest.modified
+            ;
             ''',
             [user.id]
         )

--- a/completion/tests/test_models.py
+++ b/completion/tests/test_models.py
@@ -166,9 +166,6 @@ class CompletionFetchingTestCase(CompletionSetUpMixin, TestCase):
         self.block_keys = [
             UsageKey.from_string("i4x://edX/MOOC101/video/{}".format(number)) for number in range(5)
         ]
-        self.block_keys_two = [
-            UsageKey.from_string("i4x://edX/MOOC101/video/{}".format(number)) for number in range(5)
-        ]
 
         the_completion_date = datetime.datetime(2050, 1, 1, tzinfo=UTC)
         for idx, block_key in enumerate(self.block_keys[:3]):
@@ -214,7 +211,7 @@ class CompletionFetchingTestCase(CompletionSetUpMixin, TestCase):
         self.assertDictEqual(
             models.BlockCompletion.latest_blocks_completed_all_courses(self.user_one),
             {
-                self.course_key_two: [datetime.datetime(2050, 1, 10, tzinfo=UTC), self.block_keys_two[4]],
+                self.course_key_two: [datetime.datetime(2050, 1, 10, tzinfo=UTC), self.block_keys[4]],
                 self.course_key_one: [datetime.datetime(2050, 1, 3, tzinfo=UTC), self.block_keys[2]]
             }
         )


### PR DESCRIPTION
**Description:**
We were previously including columns in the `SELECT` clause of a raw query that were not included in the `GROUP BY` clause.  This means that arbitrary row values were returned for the `block_key` column.  This PR corrects that query.
https://openedx.atlassian.net/browse/EDUCATOR-2540

**Reviewers:**
- [ ] tag @schenedx  
- [x] tag @sanfordstudent 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
Can I improve the tests in some way that would have caught this?
