### PR TITLE
EDUCATOR-2540 | More efficient query; bump freezegun version to speed up tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-* Add query method for all completions by course
+[0.1.1] - 2018-03-23
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fixes wildly inefficient raw query in BlockCompletion.latest_blocks_completed_all_courses()
+* Updates freezegun version, makes tests that use it somewhat faster.
 
 [0.1.0] - 2018-03-20
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/tests/test_models.py
+++ b/completion/tests/test_models.py
@@ -211,7 +211,7 @@ class CompletionFetchingTestCase(CompletionSetUpMixin, TestCase):
         self.assertDictEqual(
             models.BlockCompletion.latest_blocks_completed_all_courses(self.user_one),
             {
-                self.course_key_two: [datetime.datetime(2050, 1, 10, tzinfo=UTC), self.block_keys[4]],
-                self.course_key_one: [datetime.datetime(2050, 1, 3, tzinfo=UTC), self.block_keys[2]]
+                self.course_key_two: (datetime.datetime(2050, 1, 10, tzinfo=UTC), self.block_keys[4]),
+                self.course_key_one: (datetime.datetime(2050, 1, 3, tzinfo=UTC), self.block_keys[2])
             }
         )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,7 +34,7 @@ py==1.5.2                 # via tox
 pycodestyle==2.3.1
 pydocstyle==2.1.1
 pygments==2.2.0           # via diff-cover
-pyparsing==2.2.0          # via packaging
+pyparsing>=2.0.7          # via packaging
 pytz==2016.7
 pyyaml==3.12              # via edx-i18n-tools
 requests-toolbelt==0.8.0  # via twine

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -19,7 +19,7 @@ packaging==16.8           # via caniusepython3
 pycodestyle==2.3.1
 pydocstyle==2.1.1
 pylint-plugin-utils==0.2.6
-pyparsing==2.2.0          # via packaging
+pyparsing>=2.0.7          # via packaging
 requests==2.18.4          # via caniusepython3
 six==1.11.0               # via packaging, pydocstyle
 snowballstemmer==1.2.1    # via pydocstyle

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,4 +10,4 @@ py==1.5.2                 # via pytest
 pytest-cov==2.5.1
 pytest==3.3.2             # via pytest-cov, pytest-django
 six==1.11.0               # via pytest
-freezegun==0.3.8
+freezegun==0.3.10


### PR DESCRIPTION
**Description:**
* Bump freezegun to address performance issue: https://github.com/spulec/freezegun/pull/175
* Dramatically improves raw SQL query in `BlockCompletion.latest_blocks_completed_all_courses()` by including filter on user_id.

https://openedx.atlassian.net/browse/EDUCATOR-2540

**Reviewers:**
- [ ] Greg
- [ ] Simon

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

**Author concerns:**
Fear of sticking with a raw query after getting bitten with a prod outage.  Ran the new query on the read replica for my user and it seems quite snappy now, but let me know if there are any other precautions I should take:
```
mysql> SELECT
    ->     cbc.id AS id,
    ->     cbc.course_key AS course_key,
    ->     cbc.block_key AS block_key,
    ->     cbc.modified AS modified
    -> FROM
    ->     completion_blockcompletion cbc
    -> JOIN (
    ->     SELECT
    ->          course_key,
    ->          MAX(modified) AS modified
    ->     FROM
    ->          completion_blockcompletion
    ->     WHERE
    ->          user_id = 14012417
    ->     GROUP BY
    ->          course_key
    -> ) latest
    -> ON
    ->     cbc.course_key = latest.course_key AND
    ->     cbc.modified = latest.modified
    -> WHERE
    ->     user_id = 14012417;
+----------+----------------------------------+---------------------------------------------------------------------------------------------+----------------------------+
| id       | course_key                       | block_key                                                                                   | modified                   |
+----------+----------------------------------+---------------------------------------------------------------------------------------------+----------------------------+
| 47569871 | course-v1:edX+DemoX.1+2T2017     | block-v1:edX+DemoX.1+2T2017+type@html+block@b5a909bcfec7479d93d590663d14a5a1                | 2018-02-28 15:52:14.036450 |
| 64171984 | course-v1:MITx+CTL.CFx+1T2018    | block-v1:MITx+CTL.CFx+1T2018+type@library_content+block@742e753628124ae0acb7cec2fb401176    | 2018-03-12 17:13:27.842750 |
| 67091375 | course-v1:MITx+CTL.CFx+2T2017    | block-v1:MITx+CTL.CFx+2T2017+type@library_content+block@a437d9de715d45b2bc9b32b1e856fb53    | 2018-03-14 15:04:44.313577 |
| 39147472 | course-v1:MITx+CTL.SC1x_3+2T2017 | block-v1:MITx+CTL.SC1x_3+2T2017+type@library_content+block@f434fedadad14aa09b41c5f544e20663 | 2018-02-22 16:56:10.833418 |
| 64072799 | course-v1:MITx+CTL.SC2x+3T2017   | block-v1:MITx+CTL.SC2x+3T2017+type@html+block@5fdbf4c3ba604949bb9b4ba7227e6fcc              | 2018-03-12 16:03:08.110621 |
| 50521561 | course-v1:MITx+CTL.SC3x+1T2018   | block-v1:MITx+CTL.SC3x+1T2018+type@html+block@be03ac864397471ca348eaa2de42b279              | 2018-03-02 15:52:35.198217 |
+----------+----------------------------------+---------------------------------------------------------------------------------------------+----------------------------+
6 rows in set (0.00 sec)
```
