### PR TITLE
EDUCATOR-2553 | Flip site config feature gating logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.4] - 2018-03-28
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Site configurations must now explicitly disable visual progress for the
+  enable_visual_progress() feature gating function to return False early.
+
 [0.1.3] - 2018-03-26
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Added some documentation.

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/tests/test_waffle.py
+++ b/completion/tests/test_waffle.py
@@ -1,0 +1,93 @@
+"""
+Test feature-gating mechanics.
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+from contextlib import contextmanager
+
+import mock
+
+from .. import waffle
+
+
+class MockSite(object):
+    """
+    Stand-in for a Django Site object.
+    """
+    def __init__(self, config=None):
+        if config:
+            self._configuration = config
+
+    @property
+    def configuration(self):
+        """
+        Returns the MockSiteConfig attribute of this site, raises
+        MockSiteConfig.DoesNotExist if none exists.
+        """
+        if hasattr(self, '_configuration'):
+            return self._configuration
+        raise MockSiteConfig.DoesNotExist
+
+    @configuration.setter
+    def configuration(self, config):
+        """
+        Sets the configuration attribute of this site.
+        """
+        self._configuration = config
+
+
+class MockSiteConfig(object):
+    """
+    Stand-in for a Django SiteConfiguration object.
+    """
+    def __init__(self, **kwargs):
+        self.data = {k: v for k, v in kwargs.items()}
+
+    def get_value(self, key, default):
+        """
+        Returns the value corresponding to `key` in this object's data attribute.
+        """
+        return self.data.get(key, default)
+
+    class DoesNotExist(Exception):
+        """
+        Raised if a MockSiteConfig object does not exist on a MockSite.
+        """
+        pass
+
+
+@contextmanager
+def patch_get_current_site(configuration=None):
+    """
+    Monkey-patches the `get_current_site()` function and `SiteConfiguration`
+    attributes of the waffle module.
+    """
+    site = MockSite(configuration)
+
+    waffle.get_current_site = mock.Mock(return_value=site)
+    waffle.SiteConfiguration = MockSiteConfig
+
+    yield
+
+    del waffle.get_current_site
+    del waffle.SiteConfiguration
+
+
+def test_site_disables_visual_progress_is_disabled():
+    configuration = MockSiteConfig(**{waffle.ENABLE_SITE_VISUAL_PROGRESS: False})
+    with patch_get_current_site(configuration):
+        actual_value = waffle.site_disables_visual_progress()
+        assert actual_value is True
+
+
+def test_site_disables_visual_progress_no_site_config():
+    with patch_get_current_site():
+        actual_value = waffle.site_disables_visual_progress()
+        assert actual_value is False
+
+
+def test_site_disables_visual_progress_key_missing():
+    with patch_get_current_site(MockSiteConfig()):
+        actual_value = waffle.site_disables_visual_progress()
+        assert actual_value is False


### PR DESCRIPTION
**Description:**
Site configurations must explicitly disable visual progress for the `enable_visual_progress()` feature gating function to return False early.  Previously, if no configuration existed for the site, of the key corresponding to this feature was not present in the configuration, the gating function would return False early.  This PR inverses the logic: a site configuration must exist and explicitly have the feature key set to False for the gating function to return False early.

**JIRA:**
https://openedx.atlassian.net/browse/EDUCATOR-2553

**Concerns**
I wanted to add a test of this in this repo (in addition to writing an integration test in edx-platform).  It requires some monkey-patching due to the imports of things from openedx.  I think this is fine, it just looks a little non-standard.

**Reviewers:**
- [ ] @sanfordstudent  
- [x] @schenedx 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
