### PR TITLE
Remove usage of deprecated CourseStructure api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 cache:
 - pip
 before_install:
-- pip install --upgrade pip
+- pip install --upgrade pip==9.0.3
 install:
 - pip install -r requirements/travis.txt
 script:

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,5 @@ Gregory Martin <greg@edx.org>
 Alessandro Roux <aroux@edx.org>
 Sofiya Semenova <ssemenova@edx.org>
 Jeremy Bowman <jbowman@edx.org>
+Nimisha Asthagiri <nimisha@edx.org>
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,11 +13,14 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[0.1.6] - 2018-04-13
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Remove usage of deprecated CourseStructure api.
+
 [0.1.5] - 2018-04-03
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Delete enable_visual_progress methods and checks. Deprecate ENABLE_VISUAL_PROGRESS,
 ENABLE_COURSE_VISUAL_PROGRESS, and ENABLE_SITE_VISUAL_PROGRESS waffle flags
-
 
 [0.1.4] - 2018-03-28
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:**
Removes usages of the deprecated CourseStructure api in edx-platform.  This API was used to determine whether a given block actually existed in a given course.  We have replaced that logic with a much lighter weight validation that simply verifies that the given block's usage_key is associated with the course's course_key.

**Reviewers:**
- [x] @iloveagent57 
- [ ] @jcdyer 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
