### PR TITLE
EDUCATOR-3030 don't submit completion for grader's response while updating problem score.

### DIFF
--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.1.8'
+__version__ = '0.1.9'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/handlers.py
+++ b/completion/handlers.py
@@ -30,9 +30,10 @@ def scorable_block_completion(sender, **kwargs):  # pylint: disable=unused-argum
         completion = 0.0
     else:
         completion = 1.0
-    BlockCompletion.objects.submit_completion(
-        user=user,
-        course_key=course_key,
-        block_key=block_key,
-        completion=completion,
-    )
+    if not kwargs.get('grader_response'):
+        BlockCompletion.objects.submit_completion(
+            user=user,
+            course_key=course_key,
+            block_key=block_key,
+            completion=completion,
+        )


### PR DESCRIPTION
**Description:** We have seen _IntegrityErrors_ for different types of block_types. One of them is a **problem** block type. The basic problem is that we are tracking completion twice which results in a race condition in [get_or_create](https://github.com/edx/completion/blob/master/completion/models.py#L92-L98) method of **BlockCompletion** table inside [submit_completion](https://github.com/edx/completion/blob/master/completion/models.py#L42) function. This PR eliminates race condition by submitting completion once.

**JIRA:** https://openedx.atlassian.net/browse/EDUCATOR-3030
**Dependencies:** https://github.com/edx/edx-platform/pull/18834

**Reviewers:**
- [x] @iloveagent57  
- [ ] @awaisdar001  

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
