### PR TITLE
Removes refs to the completion_tracking_enabled waffle switch.

### DIFF
--- a/completion/api/v1/views.py
+++ b/completion/api/v1/views.py
@@ -24,7 +24,6 @@ try:
 except ImportError:
     pass
 
-from completion import waffle
 from completion.api.permissions import IsStaffOrOwner, IsUserInUrl
 from completion.models import BlockCompletion
 
@@ -64,11 +63,6 @@ class CompletionBatchView(APIView):
             ObjectDoesNotExist:
                 If a database object cannot be found an ObjectDoesNotExist is raised.
         """
-        if not waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
-            raise ValidationError(
-                _("BlockCompletion.objects.submit_batch_completion should not be called when the feature is disabled.")
-            )
-
         for key in self.REQUIRED_KEYS:
             if key not in batch_object:
                 raise ValidationError(_("Key '{key}' not found.".format(key=key)))

--- a/completion/handlers.py
+++ b/completion/handlers.py
@@ -8,7 +8,6 @@ from opaque_keys.edx.keys import CourseKey, UsageKey
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 
-from . import waffle
 from .models import BlockCompletion
 
 
@@ -16,8 +15,6 @@ def scorable_block_completion(sender, **kwargs):  # pylint: disable=unused-argum
     """
     When a problem is scored, submit a new BlockCompletion for that block.
     """
-    if not waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
-        return
     course_key = CourseKey.from_string(kwargs['course_id'])
     block_key = UsageKey.from_string(kwargs['usage_id'])
     block_cls = XBlock.load_class(block_key.block_type)

--- a/completion/services.py
+++ b/completion/services.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from xblock.completable import XBlockCompletionMode
 
 from .models import BlockCompletion
-from . import waffle
 
 
 class CompletionService(object):
@@ -17,7 +16,6 @@ class CompletionService(object):
 
     Exposes
 
-    * self.completion_tracking_enabled() -> bool
     * self.get_completions(candidates)
     * self.vertical_is_complete(vertical_item)
 
@@ -26,16 +24,6 @@ class CompletionService(object):
     def __init__(self, user, course_key):
         self._user = user
         self._course_key = course_key
-
-    def completion_tracking_enabled(self):
-        """
-        Exposes ENABLE_COMPLETION_TRACKING waffle switch to XModule runtime
-
-        Return value:
-
-            bool -> True if completion tracking is enabled.
-        """
-        return waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING)
 
     def get_completions(self, candidates):
         """
@@ -78,9 +66,6 @@ class CompletionService(object):
         """
         if item.location.block_type != 'vertical':
             raise ValueError('The passed in xblock is not a vertical type!')
-
-        if not self.completion_tracking_enabled():
-            return None
 
         # this is temporary local logic and will be removed when the whole course tree is included in completion
         child_locations = [

--- a/completion/test_utils.py
+++ b/completion/test_utils.py
@@ -3,7 +3,6 @@ Common functionality to support writing tests around completion.
 """
 from __future__ import absolute_import, unicode_literals
 
-from contextlib import contextmanager
 from datetime import datetime
 
 from django.contrib.auth.models import User
@@ -13,7 +12,6 @@ import mock
 from opaque_keys.edx.keys import UsageKey, CourseKey
 from pytz import UTC
 
-from . import waffle
 from .models import BlockCompletion
 
 
@@ -54,35 +52,15 @@ class UserFactory(DjangoModelFactory):
     date_joined = datetime(2011, 1, 1, tzinfo=UTC)
 
 
-class CompletionWaffleTestMixin(object):
-    """
-    Mixin to provide waffle switch overriding ability to child TestCase classes.
-    """
-
-    def override_waffle_switch(self, override):
-        """
-        Override the setting of the ENABLE_COMPLETION_TRACKING waffle switch
-        for the course of the test.
-        Parameters:
-            override (bool): True if tracking should be enabled.
-        """
-        _waffle_overrider = waffle.waffle().override(waffle.ENABLE_COMPLETION_TRACKING, override)
-        _waffle_overrider.__enter__()
-        self.addCleanup(_waffle_overrider.__exit__, None, None, None)
-
-
 class CompletionSetUpMixin(object):
     """
     Mixin to provide set_up_completion() function to child TestCase classes.
     """
-    COMPLETION_SWITCH_ENABLED = False
-
     @classmethod
     def setUpClass(cls):
         super(CompletionSetUpMixin, cls).setUpClass()
         cls.waffle_patcher = mock.patch('completion.waffle.waffle')
         cls.mock_waffle = cls.waffle_patcher.start()
-        cls.mock_waffle.return_value.is_enabled.return_value = cls.COMPLETION_SWITCH_ENABLED
 
     @classmethod
     def tearDownClass(cls):
@@ -106,12 +84,3 @@ class CompletionSetUpMixin(object):
             block_key=self.block_key,
             completion=0.5,
         )
-
-    @contextmanager
-    def override_completion_switch(self, enabled):
-        """
-        Overrides the completion-enabled waffle switch value within a context.
-        """
-        self.mock_waffle.return_value.is_enabled.return_value = enabled
-        yield
-        self.mock_waffle.return_value.is_enabled.return_value = self.COMPLETION_SWITCH_ENABLED

--- a/completion/tests/test_models.py
+++ b/completion/tests/test_models.py
@@ -36,8 +36,6 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
     Test that BlockCompletion.objects.submit_completion has the desired
     semantics.
     """
-    COMPLETION_SWITCH_ENABLED = True
-
     def setUp(self):
         super(SubmitCompletionTestCase, self).setUp()
         self.set_up_completion()
@@ -123,40 +121,11 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
         self.assertEqual(model.completion, 1.0)
 
 
-class CompletionDisabledTestCase(CompletionSetUpMixin, TestCase):
-    """
-    Test that completion is not track when the feature switch is disabled.
-    """
-    COMPLETION_SWITCH_ENABLED = False
-
-    def setUp(self):
-        super(CompletionDisabledTestCase, self).setUp()
-        self.set_up_completion()
-
-    def test_cannot_call_submit_completion(self):
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
-        with self.assertRaises(RuntimeError):
-            models.BlockCompletion.objects.submit_completion(
-                user=self.user,
-                course_key=self.block_key.course_key,
-                block_key=self.block_key,
-                completion=0.9,
-            )
-        self.assertEqual(models.BlockCompletion.objects.count(), 1)
-
-    def test_submit_batch_completion_without_waffle(self):
-        with self.assertRaises(RuntimeError):
-            blocks = [(self.block_key, 1.0)]
-            models.BlockCompletion.objects.submit_batch_completion(self.user, self.course_key, blocks)
-
-
 class CompletionFetchingTestCase(CompletionSetUpMixin, TestCase):
     """
     Test model methods:
         latest completion per course, and all completions per course
     """
-    COMPLETION_SWITCH_ENABLED = True
-
     def setUp(self):
         super(CompletionFetchingTestCase, self).setUp()
         self.user_one = UserFactory.create()

--- a/completion/tests/test_services.py
+++ b/completion/tests/test_services.py
@@ -79,11 +79,6 @@ class CompletionServiceTestCase(CompletionSetUpMixin, TestCase):
         expected_completions = dict(zip(expected_block_keys, [1.0, 0.8, 0.6, 0.0, 0.0]))
         self.assertEqual(expected_completions, actual_completions)
 
-    @ddt.data(True, False)
-    def test_enabled_honors_waffle_switch(self, enabled):
-        with self.override_completion_switch(enabled):
-            self.assertEqual(self.completion_service.completion_tracking_enabled(), enabled)
-
     @ddt.data(
         (XBlockCompletionMode.COMPLETABLE, False, False, True),
         (XBlockCompletionMode.COMPLETABLE, True, False, False),

--- a/completion/waffle.py
+++ b/completion/waffle.py
@@ -2,7 +2,7 @@
 This module contains various configuration settings via
 waffle switches for the completion app.
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 try:
     from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
@@ -11,15 +11,6 @@ except ImportError:
 
 # Namespace
 WAFFLE_NAMESPACE = 'completion'
-
-# Switches
-
-# Full name: completion.enable_completion_tracking
-# Indicates whether or not to track completion of individual blocks.  Keeping
-# this disabled will prevent creation of BlockCompletion objects in the
-# database, as well as preventing completion-related network access by certain
-# xblocks.
-ENABLE_COMPLETION_TRACKING = 'enable_completion_tracking'
 
 
 def waffle():


### PR DESCRIPTION
**Description:**
We only needed this switch for rollout, this PR removes references to it.

**JIRA:**
https://openedx.atlassian.net/browse/EDUCATOR-3358

**Reviewers:**
- [ ] tag reviwer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
