### PR TITLE
Use xblock get_mode method to determine completion mode.

### DIFF
--- a/completion/handlers.py
+++ b/completion/handlers.py
@@ -21,7 +21,7 @@ def scorable_block_completion(sender, **kwargs):  # pylint: disable=unused-argum
     course_key = CourseKey.from_string(kwargs['course_id'])
     block_key = UsageKey.from_string(kwargs['usage_id'])
     block_cls = XBlock.load_class(block_key.block_type)
-    if getattr(block_cls, 'completion_mode', XBlockCompletionMode.COMPLETABLE) != XBlockCompletionMode.COMPLETABLE:
+    if XBlockCompletionMode.get_mode(block_cls) != XBlockCompletionMode.COMPLETABLE:
         return
     if getattr(block_cls, 'has_custom_completion', False):
         return

--- a/completion/services.py
+++ b/completion/services.py
@@ -105,7 +105,7 @@ class CompletionService(object):
         This is true of any non-customized, non-scorable, completable block.
         """
         return (
-            getattr(block, 'completion_mode', XBlockCompletionMode.COMPLETABLE) == XBlockCompletionMode.COMPLETABLE
+            XBlockCompletionMode.get_mode(block) == XBlockCompletionMode.COMPLETABLE
             and not getattr(block, 'has_custom_completion', False)
             and not getattr(block, 'has_score', False)
         )

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,4 +5,5 @@ django-model-utils        # Provides TimeStampedModel abstract base class
 djangorestframework>=3.2.0,<3.7.0  # REST API framework
 edx-opaque-keys[django]   # Create and introspect course and xblock identities
 pytz                      # Time zone support
-XBlock                    # Courseware component architecture
+#XBlock>=1.2.2             # Courseware component architecture
+-e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,5 +5,4 @@ django-model-utils        # Provides TimeStampedModel abstract base class
 djangorestframework>=3.2.0,<3.7.0  # REST API framework
 edx-opaque-keys[django]   # Create and introspect course and xblock identities
 pytz                      # Time zone support
-#XBlock>=1.2.2             # Courseware component architecture
--e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
+XBlock>=1.2.2             # Courseware component architecture

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,6 @@
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
 
--e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
 appdirs==1.4.3            # via fs
 argparse==1.4.0           # via caniusepython3
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery
@@ -31,7 +30,7 @@ factory-boy==2.11.1
 faker==0.9.0              # via factory-boy
 first==2.0.1              # via pip-tools
 freezegun==0.3.10
-fs==2.1.0
+fs==2.1.0                 # via xblock
 futures==3.1.1 ; python_version >= "3"
 idna==2.7                 # via requests
 inflect==1.0.0            # via jinja2-pluralize
@@ -39,8 +38,8 @@ isort==4.3.4
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.3.1  # via astroid
-lxml==4.2.4
-markupsafe==1.0           # via jinja2
+lxml==4.2.4               # via xblock
+markupsafe==1.0           # via jinja2, xblock
 mccabe==0.6.1             # via pylint
 mock==2.0.0
 more-itertools==4.3.0     # via pytest
@@ -64,11 +63,11 @@ pyparsing==2.2.0          # via packaging
 pytest-cov==2.6.0
 pytest-django==3.4.2
 pytest==3.8.0             # via pytest-cov, pytest-django
-python-dateutil==2.7.3    # via faker, freezegun
+python-dateutil==2.7.3    # via faker, freezegun, xblock
 pytz==2018.5
-pyyaml==3.13              # via edx-i18n-tools
+pyyaml==3.13              # via edx-i18n-tools, xblock
 requests==2.19.1          # via caniusepython3
-six==1.11.0               # via astroid, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pip-tools, pydocstyle, pylint, pytest, python-dateutil, stevedore, tox
+six==1.11.0               # via astroid, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pip-tools, pydocstyle, pylint, pytest, python-dateutil, stevedore, tox, xblock
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.29.0         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
@@ -77,6 +76,7 @@ tox==3.2.1
 typing==3.6.6             # via fs
 urllib3==1.23             # via requests
 virtualenv==16.0.0        # via tox
-web-fragments==0.2.2
-webob==1.8.2
+web-fragments==0.2.2      # via xblock
+webob==1.8.2              # via xblock
 wrapt==1.10.11            # via astroid
+xblock==1.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,80 +4,79 @@
 #
 #    pip-compile --output-file requirements/dev.txt requirements/dev.in
 #
+
+-e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
 appdirs==1.4.3            # via fs
 argparse==1.4.0           # via caniusepython3
-astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
-attrs==17.4.0             # via pytest
-backports.functools-lru-cache==1.5  # via astroid, caniusepython3, pylint
-caniusepython3==6.0.0
-certifi==2018.1.18        # via requests
+astroid==1.5.2            # via edx-lint, pylint, pylint-celery
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via pytest
+backports.functools-lru-cache==1.5  # via caniusepython3
+caniusepython3==7.0.0
+certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint, pip-tools
-configparser==3.5.0       # via pylint
 coverage==4.5.1           # via pytest-cov
-ddt==1.1.2
-diff-cover==1.0.2
-distlib==0.2.6            # via caniusepython3
-django-model-utils==3.1.1
-django==1.11.11
+ddt==1.2.0
+diff-cover==1.0.4
+distlib==0.2.7            # via caniusepython3
+django-model-utils==3.1.2
+django==1.11.15
 djangorestframework==3.6.4
-edx-i18n-tools==0.4.3
+edx-i18n-tools==0.4.7
 edx-lint==0.5.5
-edx-opaque-keys[django]==0.4.3
-enum34==1.1.6             # via astroid, fs
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+edx-opaque-keys[django]==0.4.4
+factory-boy==2.11.1
+faker==0.9.0              # via factory-boy
 first==2.0.1              # via pip-tools
 freezegun==0.3.10
-fs==2.0.20                # via xblock
-funcsigs==1.0.2           # via mock, pytest
+fs==2.1.0
 futures==3.1.1 ; python_version >= "3"
-idna==2.6                 # via requests
-inflect==0.2.5            # via jinja2-pluralize
-ipaddress==1.0.19         # via faker
+idna==2.7                 # via requests
+inflect==1.0.0            # via jinja2-pluralize
 isort==4.3.4
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10              # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.3.1  # via astroid
-lxml==4.2.1               # via xblock
-markupsafe==1.0           # via jinja2, xblock
+lxml==4.2.4
+markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-more-itertools==4.1.0     # via pytest
+more-itertools==4.3.0     # via pytest
 packaging==17.1           # via caniusepython3
-path.py==11.0             # via edx-i18n-tools
-pbr==3.1.1                # via mock, stevedore
-pip-tools==1.11.0
-pluggy==0.6.0             # via pytest, tox
+path.py==11.1.0           # via edx-i18n-tools
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock, stevedore
+pip-tools==2.0.2
+pluggy==0.7.1             # via pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-py==1.5.3                 # via pytest, tox
-pycodestyle==2.3.1
+py==1.6.0                 # via pytest, tox
+pycodestyle==2.4.0
 pydocstyle==2.1.1
 pygments==2.2.0           # via diff-cover
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.6.1            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
-pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.5.0             # via pytest-cov, pytest-django
-python-dateutil==2.7.0    # via faker, freezegun, xblock
-pytz==2018.3
-pyyaml==3.12              # via edx-i18n-tools, xblock
-requests==2.18.4          # via caniusepython3
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via astroid, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pip-tools, pydocstyle, pylint, pytest, python-dateutil, singledispatch, stevedore, tox, xblock
+pytest-cov==2.6.0
+pytest-django==3.4.2
+pytest==3.8.0             # via pytest-cov, pytest-django
+python-dateutil==2.7.3    # via faker, freezegun
+pytz==2018.5
+pyyaml==3.13              # via edx-i18n-tools
+requests==2.19.1          # via caniusepython3
+six==1.11.0               # via astroid, diff-cover, edx-i18n-tools, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pip-tools, pydocstyle, pylint, pytest, python-dateutil, stevedore, tox
 snowballstemmer==1.2.1    # via pydocstyle
-stevedore==1.28.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
-tox-battery==0.5
-tox==2.9.1
-urllib3==1.22             # via requests
-virtualenv==15.2.0        # via tox
-web-fragments==0.2.2      # via xblock
-webob==1.7.4              # via xblock
+tox-battery==0.5.1
+tox==3.2.1
+typing==3.6.6             # via fs
+urllib3==1.23             # via requests
+virtualenv==16.0.0        # via tox
+web-fragments==0.2.2
+webob==1.8.2
 wrapt==1.10.11            # via astroid
-xblock==1.1.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,7 +5,6 @@
 #    pip-compile --output-file requirements/doc.txt requirements/doc.in
 #
 
--e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
 alabaster==0.7.11         # via sphinx
 appdirs==1.4.3            # via fs
 atomicwrites==1.2.1       # via pytest
@@ -28,14 +27,14 @@ edx-sphinx-theme==1.3.0
 factory-boy==2.11.1
 faker==0.9.0              # via factory-boy
 freezegun==0.3.10
-fs==2.1.0
+fs==2.1.0                 # via xblock
 future==0.16.0            # via readme-renderer
 html5lib==1.0.1           # via bleach
 idna==2.7                 # via requests
 imagesize==1.1.0          # via sphinx
 jinja2==2.10              # via sphinx
-lxml==4.2.4
-markupsafe==1.0           # via jinja2
+lxml==4.2.4               # via xblock
+markupsafe==1.0           # via jinja2, xblock
 mock==2.0.0
 more-itertools==4.3.0     # via pytest
 packaging==17.1           # via sphinx
@@ -50,13 +49,13 @@ pyparsing==2.2.0          # via packaging
 pytest-cov==2.6.0
 pytest-django==3.4.2
 pytest==3.8.0             # via pytest-cov, pytest-django
-python-dateutil==2.7.3    # via faker, freezegun
+python-dateutil==2.7.3    # via faker, freezegun, xblock
 pytz==2018.5
-pyyaml==3.13
+pyyaml==3.13              # via xblock
 readme-renderer==21.0
 requests==2.19.1          # via sphinx
 restructuredtext-lint==1.1.3  # via doc8
-six==1.11.0               # via bleach, doc8, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, fs, html5lib, mock, more-itertools, packaging, pathlib2, pytest, python-dateutil, readme-renderer, sphinx, stevedore
+six==1.11.0               # via bleach, doc8, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, fs, html5lib, mock, more-itertools, packaging, pathlib2, pytest, python-dateutil, readme-renderer, sphinx, stevedore, xblock
 snowballstemmer==1.2.1    # via sphinx
 sphinx==1.7.9
 sphinxcontrib-websupport==1.1.0  # via sphinx
@@ -64,6 +63,7 @@ stevedore==1.29.0         # via doc8, edx-opaque-keys
 text-unidecode==1.2       # via faker
 typing==3.6.6             # via fs
 urllib3==1.23             # via requests
-web-fragments==0.2.2
+web-fragments==0.2.2      # via xblock
 webencodings==0.5.1       # via html5lib
-webob==1.8.2
+webob==1.8.2              # via xblock
+xblock==1.2.2

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,64 +4,66 @@
 #
 #    pip-compile --output-file requirements/doc.txt requirements/doc.in
 #
-alabaster==0.7.10         # via sphinx
+
+-e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
+alabaster==0.7.11         # via sphinx
 appdirs==1.4.3            # via fs
-attrs==17.4.0             # via pytest
-babel==2.5.3              # via sphinx
-bleach==2.1.3             # via readme-renderer
-certifi==2018.1.18        # via requests
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via pytest
+babel==2.6.0              # via sphinx
+bleach==2.1.4             # via readme-renderer
+certifi==2018.8.24        # via requests
+cffi==1.11.5              # via cmarkgfm
 chardet==3.0.4            # via doc8, requests
-commonmark==0.7.5         # via readme-renderer
+cmarkgfm==0.4.2           # via readme-renderer
 coverage==4.5.1           # via pytest-cov
-ddt==1.1.2
-django-model-utils==3.1.1
-django==1.11.11
+ddt==1.2.0
+django-model-utils==3.1.2
+django==1.11.15
 djangorestframework==3.6.4
 doc8==0.8.0
 docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
-edx-opaque-keys[django]==0.4.3
+edx-opaque-keys[django]==0.4.4
 edx-sphinx-theme==1.3.0
-enum34==1.1.6             # via fs
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+factory-boy==2.11.1
+faker==0.9.0              # via factory-boy
 freezegun==0.3.10
-fs==2.0.20                # via xblock
-funcsigs==1.0.2           # via mock, pytest
-future==0.16.0            # via commonmark
+fs==2.1.0
+future==0.16.0            # via readme-renderer
 html5lib==1.0.1           # via bleach
-idna==2.6                 # via requests
-imagesize==1.0.0          # via sphinx
-ipaddress==1.0.19         # via faker
+idna==2.7                 # via requests
+imagesize==1.1.0          # via sphinx
 jinja2==2.10              # via sphinx
-lxml==4.2.1               # via xblock
-markupsafe==1.0           # via jinja2, xblock
+lxml==4.2.4
+markupsafe==1.0           # via jinja2
 mock==2.0.0
-more-itertools==4.1.0     # via pytest
+more-itertools==4.3.0     # via pytest
 packaging==17.1           # via sphinx
-pbr==3.1.1                # via mock, stevedore
-pluggy==0.6.0             # via pytest
-py==1.5.3                 # via pytest
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock, stevedore
+pluggy==0.7.1             # via pytest
+py==1.6.0                 # via pytest
+pycparser==2.18           # via cffi
 pygments==2.2.0           # via readme-renderer, sphinx
-pymongo==3.6.1            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
-pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.5.0             # via pytest-cov, pytest-django
-python-dateutil==2.7.0    # via faker, freezegun, xblock
-pytz==2018.3
-pyyaml==3.12              # via xblock
-readme-renderer==17.4
-requests==2.18.4          # via sphinx
+pytest-cov==2.6.0
+pytest-django==3.4.2
+pytest==3.8.0             # via pytest-cov, pytest-django
+python-dateutil==2.7.3    # via faker, freezegun
+pytz==2018.5
+pyyaml==3.13
+readme-renderer==21.0
+requests==2.19.1          # via sphinx
 restructuredtext-lint==1.1.3  # via doc8
-six==1.11.0               # via bleach, doc8, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, fs, html5lib, mock, more-itertools, packaging, pytest, python-dateutil, readme-renderer, sphinx, stevedore, xblock
+six==1.11.0               # via bleach, doc8, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, fs, html5lib, mock, more-itertools, packaging, pathlib2, pytest, python-dateutil, readme-renderer, sphinx, stevedore
 snowballstemmer==1.2.1    # via sphinx
-sphinx==1.7.2
-sphinxcontrib-websupport==1.0.1  # via sphinx
-stevedore==1.28.0         # via doc8, edx-opaque-keys
+sphinx==1.7.9
+sphinxcontrib-websupport==1.1.0  # via sphinx
+stevedore==1.29.0         # via doc8, edx-opaque-keys
 text-unidecode==1.2       # via faker
-typing==3.6.4             # via sphinx
-urllib3==1.22             # via requests
-web-fragments==0.2.2      # via xblock
+typing==3.6.6             # via fs
+urllib3==1.23             # via requests
+web-fragments==0.2.2
 webencodings==0.5.1       # via html5lib
-webob==1.7.4              # via xblock
-xblock==1.1.1
+webob==1.8.2

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,7 +5,6 @@
 #    pip-compile --output-file requirements/quality.txt requirements/quality.in
 #
 
--e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
 appdirs==1.4.3            # via fs
 argparse==1.4.0           # via caniusepython3
 astroid==1.5.2            # via edx-lint, pylint, pylint-celery
@@ -28,13 +27,13 @@ edx-opaque-keys[django]==0.4.4
 factory-boy==2.11.1
 faker==0.9.0              # via factory-boy
 freezegun==0.3.10
-fs==2.1.0
+fs==2.1.0                 # via xblock
 futures==3.1.1 ; python_version >= "3"
 idna==2.7                 # via requests
 isort==4.3.4
 lazy-object-proxy==1.3.1  # via astroid
-lxml==4.2.4
-markupsafe==1.0
+lxml==4.2.4               # via xblock
+markupsafe==1.0           # via xblock
 mccabe==0.6.1             # via pylint
 mock==2.0.0
 more-itertools==4.3.0     # via pytest
@@ -54,16 +53,17 @@ pyparsing==2.2.0          # via packaging
 pytest-cov==2.6.0
 pytest-django==3.4.2
 pytest==3.8.0             # via pytest-cov, pytest-django
-python-dateutil==2.7.3    # via faker, freezegun
+python-dateutil==2.7.3    # via faker, freezegun, xblock
 pytz==2018.5
-pyyaml==3.13
+pyyaml==3.13              # via xblock
 requests==2.19.1          # via caniusepython3
-six==1.11.0               # via astroid, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pydocstyle, pylint, pytest, python-dateutil, stevedore
+six==1.11.0               # via astroid, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pydocstyle, pylint, pytest, python-dateutil, stevedore, xblock
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.29.0         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
 typing==3.6.6             # via fs
 urllib3==1.23             # via requests
-web-fragments==0.2.2
-webob==1.8.2
+web-fragments==0.2.2      # via xblock
+webob==1.8.2              # via xblock
 wrapt==1.10.11            # via astroid
+xblock==1.2.2

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,67 +4,66 @@
 #
 #    pip-compile --output-file requirements/quality.txt requirements/quality.in
 #
+
+-e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
 appdirs==1.4.3            # via fs
 argparse==1.4.0           # via caniusepython3
-astroid==1.5.2            # via edx-lint, pylint, pylint-celery, pylint-plugin-utils
-attrs==17.4.0             # via pytest
-backports.functools-lru-cache==1.5  # via astroid, caniusepython3, pylint
-caniusepython3==6.0.0
-certifi==2018.1.18        # via requests
+astroid==1.5.2            # via edx-lint, pylint, pylint-celery
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via pytest
+backports.functools-lru-cache==1.5  # via caniusepython3
+caniusepython3==7.0.0
+certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
 click-log==0.1.8          # via edx-lint
 click==6.7                # via click-log, edx-lint
-configparser==3.5.0       # via pylint
 coverage==4.5.1           # via pytest-cov
-ddt==1.1.2
-distlib==0.2.6            # via caniusepython3
-django-model-utils==3.1.1
-django==1.11.11
+ddt==1.2.0
+distlib==0.2.7            # via caniusepython3
+django-model-utils==3.1.2
+django==1.11.15
 djangorestframework==3.6.4
 edx-lint==0.5.5
-edx-opaque-keys[django]==0.4.3
-enum34==1.1.6             # via astroid, fs
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+edx-opaque-keys[django]==0.4.4
+factory-boy==2.11.1
+faker==0.9.0              # via factory-boy
 freezegun==0.3.10
-fs==2.0.20                # via xblock
-funcsigs==1.0.2           # via mock, pytest
+fs==2.1.0
 futures==3.1.1 ; python_version >= "3"
-idna==2.6                 # via requests
-ipaddress==1.0.19         # via faker
+idna==2.7                 # via requests
 isort==4.3.4
 lazy-object-proxy==1.3.1  # via astroid
-lxml==4.2.1               # via xblock
-markupsafe==1.0           # via xblock
+lxml==4.2.4
+markupsafe==1.0
 mccabe==0.6.1             # via pylint
 mock==2.0.0
-more-itertools==4.1.0     # via pytest
+more-itertools==4.3.0     # via pytest
 packaging==17.1           # via caniusepython3
-pbr==3.1.1                # via mock, stevedore
-pluggy==0.6.0             # via pytest
-py==1.5.3                 # via pytest
-pycodestyle==2.3.1
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock, stevedore
+pluggy==0.7.1             # via pytest
+py==1.6.0                 # via pytest
+pycodestyle==2.4.0
 pydocstyle==2.1.1
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
-pylint-plugin-utils==0.2.6  # via pylint-celery, pylint-django
+pylint-plugin-utils==0.4  # via pylint-celery, pylint-django
 pylint==1.7.1             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.6.1            # via edx-opaque-keys
+pymongo==3.7.1            # via edx-opaque-keys
 pyparsing==2.2.0          # via packaging
-pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.5.0             # via pytest-cov, pytest-django
-python-dateutil==2.7.0    # via faker, freezegun, xblock
-pytz==2018.3
-pyyaml==3.12              # via xblock
-requests==2.18.4          # via caniusepython3
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via astroid, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pydocstyle, pylint, pytest, python-dateutil, singledispatch, stevedore, xblock
+pytest-cov==2.6.0
+pytest-django==3.4.2
+pytest==3.8.0             # via pytest-cov, pytest-django
+python-dateutil==2.7.3    # via faker, freezegun
+pytz==2018.5
+pyyaml==3.13
+requests==2.19.1          # via caniusepython3
+six==1.11.0               # via astroid, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pydocstyle, pylint, pytest, python-dateutil, stevedore
 snowballstemmer==1.2.1    # via pydocstyle
-stevedore==1.28.0         # via edx-opaque-keys
+stevedore==1.29.0         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
-urllib3==1.22             # via requests
-web-fragments==0.2.2      # via xblock
-webob==1.7.4              # via xblock
+typing==3.6.6             # via fs
+urllib3==1.23             # via requests
+web-fragments==0.2.2
+webob==1.8.2
 wrapt==1.10.11            # via astroid
-xblock==1.1.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,6 @@
 #    pip-compile --output-file requirements/test.txt requirements/test.in
 #
 
--e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
 appdirs==1.4.3            # via fs
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
@@ -17,9 +16,9 @@ edx-opaque-keys[django]==0.4.4
 factory-boy==2.11.1
 faker==0.9.0              # via factory-boy
 freezegun==0.3.10
-fs==2.1.0
-lxml==4.2.4
-markupsafe==1.0
+fs==2.1.0                 # via xblock
+lxml==4.2.4               # via xblock
+markupsafe==1.0           # via xblock
 mock==2.0.0
 more-itertools==4.3.0     # via pytest
 pathlib2==2.3.2           # via pytest
@@ -30,12 +29,13 @@ pymongo==3.7.1            # via edx-opaque-keys
 pytest-cov==2.6.0
 pytest-django==3.4.2
 pytest==3.8.0             # via pytest-cov, pytest-django
-python-dateutil==2.7.3    # via faker, freezegun
+python-dateutil==2.7.3    # via faker, freezegun, xblock
 pytz==2018.5
-pyyaml==3.13
-six==1.11.0               # via edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, pathlib2, pytest, python-dateutil, stevedore
+pyyaml==3.13              # via xblock
+six==1.11.0               # via edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, pathlib2, pytest, python-dateutil, stevedore, xblock
 stevedore==1.29.0         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
 typing==3.6.6             # via fs
-web-fragments==0.2.2
-webob==1.8.2
+web-fragments==0.2.2      # via xblock
+webob==1.8.2              # via xblock
+xblock==1.2.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,37 +4,38 @@
 #
 #    pip-compile --output-file requirements/test.txt requirements/test.in
 #
+
+-e git+https://github.com/edx/XBlock@cliff/completion-get-mode#egg=XBlock==1.2.2a1
 appdirs==1.4.3            # via fs
-attrs==17.4.0             # via pytest
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via pytest
 coverage==4.5.1           # via pytest-cov
-ddt==1.1.2
-django-model-utils==3.1.1
+ddt==1.2.0
+django-model-utils==3.1.2
 djangorestframework==3.6.4
-edx-opaque-keys[django]==0.4.3
-enum34==1.1.6             # via fs
-factory-boy==2.10.0
-faker==0.8.12             # via factory-boy
+edx-opaque-keys[django]==0.4.4
+factory-boy==2.11.1
+faker==0.9.0              # via factory-boy
 freezegun==0.3.10
-fs==2.0.20                # via xblock
-funcsigs==1.0.2           # via mock, pytest
-ipaddress==1.0.19         # via faker
-lxml==4.2.1               # via xblock
-markupsafe==1.0           # via xblock
+fs==2.1.0
+lxml==4.2.4
+markupsafe==1.0
 mock==2.0.0
-more-itertools==4.1.0     # via pytest
-pbr==3.1.1                # via mock, stevedore
-pluggy==0.6.0             # via pytest
-py==1.5.3                 # via pytest
-pymongo==3.6.1            # via edx-opaque-keys
-pytest-cov==2.5.1
-pytest-django==3.1.2
-pytest==3.5.0             # via pytest-cov, pytest-django
-python-dateutil==2.7.0    # via faker, freezegun, xblock
-pytz==2018.3
-pyyaml==3.12              # via xblock
-six==1.11.0               # via edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, pytest, python-dateutil, stevedore, xblock
-stevedore==1.28.0         # via edx-opaque-keys
+more-itertools==4.3.0     # via pytest
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock, stevedore
+pluggy==0.7.1             # via pytest
+py==1.6.0                 # via pytest
+pymongo==3.7.1            # via edx-opaque-keys
+pytest-cov==2.6.0
+pytest-django==3.4.2
+pytest==3.8.0             # via pytest-cov, pytest-django
+python-dateutil==2.7.3    # via faker, freezegun
+pytz==2018.5
+pyyaml==3.13
+six==1.11.0               # via edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, pathlib2, pytest, python-dateutil, stevedore
+stevedore==1.29.0         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
-web-fragments==0.2.2      # via xblock
-webob==1.7.4              # via xblock
-xblock==1.1.1
+typing==3.6.6             # via fs
+web-fragments==0.2.2
+webob==1.8.2

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,16 +4,17 @@
 #
 #    pip-compile --output-file requirements/travis.txt requirements/travis.in
 #
-certifi==2018.1.18        # via requests
+
+certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
 codecov==2.0.15
 coverage==4.5.1           # via codecov
-idna==2.6                 # via requests
-pluggy==0.6.0             # via tox
-py==1.5.3                 # via tox
-requests==2.18.4          # via codecov
+idna==2.7                 # via requests
+pluggy==0.7.1             # via tox
+py==1.6.0                 # via tox
+requests==2.19.1          # via codecov
 six==1.11.0               # via tox
-tox-battery==0.5
-tox==2.9.1
-urllib3==1.22             # via requests
-virtualenv==15.2.0        # via tox
+tox-battery==0.5.1
+tox==3.2.1
+urllib3==1.23             # via requests
+virtualenv==16.0.0        # via tox


### PR DESCRIPTION
**Description:** A new method was added to XBlockCompletionMode to return the mode, in order to centralize the logic around unspecified completion_mode meaning "completable."

It was just released in XBlock 1.2.2.  This PR puts it to use.

**JIRA:** Tangential to OC-5161

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:** List testing instructions

**Reviewers:**
- [x] @xitij2000
- [x] @jmbowman 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
