### PR TITLE
Catch IntegrityError, and retry with BlockCompletion.objects.get()

### DIFF
--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.1.9'
+__version__ = '0.1.10'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/tests/test_models.py
+++ b/completion/tests/test_models.py
@@ -43,7 +43,7 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
         self.set_up_completion()
 
     def test_changed_value(self):
-        with self.assertNumQueries(4):  # Get, update, 2 * savepoints
+        with self.assertNumQueries(6):  # Get, update, 2 * savepoints, 2 * exists checks
             completion, isnew = models.BlockCompletion.objects.submit_completion(
                 user=self.user,
                 course_key=self.course_key,
@@ -56,7 +56,7 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
         self.assertEqual(models.BlockCompletion.objects.count(), 1)
 
     def test_unchanged_value(self):
-        with self.assertNumQueries(1):  # Get
+        with self.assertNumQueries(3):  # Get + 2 * savepoints
             completion, isnew = models.BlockCompletion.objects.submit_completion(
                 user=self.user,
                 course_key=self.course_key,
@@ -70,7 +70,7 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
 
     def test_new_user(self):
         newuser = UserFactory()
-        with self.assertNumQueries(4):  # Get, update, 2 * savepoints
+        with self.assertNumQueries(6):  # Get, update, 4 * savepoints
             _, isnew = models.BlockCompletion.objects.submit_completion(
                 user=newuser,
                 course_key=self.course_key,
@@ -82,7 +82,7 @@ class SubmitCompletionTestCase(CompletionSetUpMixin, TestCase):
 
     def test_new_block(self):
         newblock = UsageKey.from_string(u'block-v1:edx+test+run+type@video+block@puppers')
-        with self.assertNumQueries(4):  # Get, update, 2 * savepoints
+        with self.assertNumQueries(6):  # Get, update, 4 * savepoints
             _, isnew = models.BlockCompletion.objects.submit_completion(
                 user=self.user,
                 course_key=newblock.course_key,


### PR DESCRIPTION
**Description:** Reintroduces IntegrityError checking around creating BlockCompletions, and 
adds atomic block as well as revising kwargs fields in get_or_create call.

**JIRA:** OC-5248

**Dependencies:** N/A

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:** List testing instructions

**Reviewers:**
- [ ] @bradenmacdonald  
- [x] @pomegranited 

FYI: @Rabia23 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
