### PR TITLE
Fix Django20 deprecation warning.

### DIFF
--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.1.10'
+__version__ = '0.1.11'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/api/urls.py
+++ b/completion/api/urls.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 
+app_name = 'completion'  # pylint: disable=invalid-name
 urlpatterns = [
-    url(r'^v1/', include('completion.api.v1.urls', namespace='v1')),
+    url(r'^v1/', include('completion.api.v1.urls')),
 ]


### PR DESCRIPTION
**Description:** Fixes this warning in edx-platform:
```
openedx/core/djangoapps/user_api/accounts/tests/test_retirement_views.py::TestAccountDeactivation::test_on_jwt_headers_rejection
  /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/completion/api/urls.py:10: RemovedInDjango20Warning: Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated. Set the app_name attribute in the included module, or pass a 2-tuple containing the list of patterns and app_name instead.
    url(r'^v1/', include('completion.api.v1.urls', namespace='v1')),
/edx/app/edxapp/edx-platform/lms/urls.py:110: RemovedInDjango20Warning: Specifying a namespace in django.conf.urls.include() without providing an app_name is deprecated. Set the app_name attribute in the included module, or pass a 2-tuple containing the list of patterns and app_name instead.
    url(r'^api/completion/', include('completion.api.urls', namespace='completion_api')),
```
**JIRA:** None

**Dependencies:** None

**Installation instructions:** None

**Testing instructions:** None

**Reviewers:**
- [ ] tag reviwer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
