### PR TITLE
v0.1.15 add Oauth2 auth

### DIFF
--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '0.1.14'
+__version__ = '0.1.15'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/api/v1/views.py
+++ b/completion/api/v1/views.py
@@ -22,6 +22,7 @@ from six import text_type
 try:
     from student.models import CourseEnrollment
     from lms.djangoapps.course_api.blocks.api import get_blocks
+    from openedx.core.lib.api.authentication import OAuth2AuthenticationAllowInactiveUser
 except ImportError:
     pass
 
@@ -34,7 +35,9 @@ class CompletionBatchView(APIView):
     """
     Handles API requests to submit batch completions.
     """
-    authentication_classes = (JwtAuthentication, SessionAuthenticationAllowInactiveUser,)
+    authentication_classes = (
+        JwtAuthentication, SessionAuthenticationAllowInactiveUser, OAuth2AuthenticationAllowInactiveUser,
+    )
     permission_classes = (permissions.IsAuthenticated, IsStaffOrOwner,)
     REQUIRED_KEYS = ['username', 'course_key', 'blocks']
 


### PR DESCRIPTION
**Description:**  This PR adds the Oauth2 authentication to the v1 endpoint.  Note, this is to backport functionality to the 0.1.x release track, because 1.x doesn't currently work on ginkgo.

**JIRA:** BB-754

**Testing instructions:** List testing instructions

1.  Install this version to a solutions devstack.
2.  Grab an Oauth2 token using the terminal:

    ```
    curl -d 'client_id=shell&client_secret=secret&grant_type=password&username=staff&password=edx' http://localhost:8000/oauth2/access_token/
    ```
3.  Make a request using the token and make sure it works correctly:
    ```
    curl -H "Authorization: $TOKEN" -d '{"username":"staff"}' localhost:8000/api/completion/v1/completion-batch
    ```


**Reviewers:**
- [ ] @viadanna 
- [ ] @

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

