### PR TITLE
Reorder authentication classes to counter 403 error on iOS app

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Usman Khalid <usman@opencraft.com>
 Rabia Iftikhar <rabiaiftikhar2392@gmail.com>
 Ahsan Ulhaq <ahsan@edx.org>
 Robert Raposa <rraposa@edx.org>
+Syed Muhammad Dawoud Sheraz Ali <dsheraz@edx.org>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[1.0.2] - 2019-03-11
+--------------------
+
+* Fix the 403 error occurring for completion-batch API for requests coming from the iOS devices
 
 [1.0.0] - 2018-10-16
 --------------------

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/api/v1/views.py
+++ b/completion/api/v1/views.py
@@ -37,7 +37,7 @@ class CompletionBatchView(APIView):
     Handles API requests to submit batch completions.
     """
     authentication_classes = (
-        JwtAuthentication, SessionAuthenticationAllowInactiveUser, OAuth2AuthenticationAllowInactiveUser,
+        JwtAuthentication, OAuth2AuthenticationAllowInactiveUser, SessionAuthenticationAllowInactiveUser,
     )
     permission_classes = (permissions.IsAuthenticated, IsStaffOrOwner,)
     REQUIRED_KEYS = ['username', 'course_key', 'blocks']


### PR DESCRIPTION
**Description:**  The completion-batch API is used by the mobile team to mark a block containing video as complete when the video finishes. The API uses some different authentication mechanisms to verify the learner and underlying content. The current scheme, where SessionAuthentication is before OAuth2, caused issues on the iOS app. The problem was happening that both token and session ids were being sent in the request. Since SessionAuth was first, it tried to authenticate using that class. In the request, the **Referer** field was missing, which is necessary in the case of SessionAuth, which led to 403 error. The interesting part was that the iOS app uses the same request generation methodology for other APIs and they were working fine. All those APIs had the OAuth2 before SessionAuth([example](https://github.com/edx/edx-platform/blob/master/lms/djangoapps/discussion_api/views.py#L642)). This PR replicates the same behavior to counter the 403 errors that are taking place because of the incorrect order.

**EDUCATOR-3926:** https://openedx.atlassian.net/browse/EDUCATOR-3926

**Dependencies:** Platform [PR](https://github.com/edx/edx-platform/pull/19962)

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:** List testing instructions

**Reviewers:**
- [x] tag reviwer 
- [x] tag reviewer 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed
- [x] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
