### PR TITLE
BB-1060: DRF extensions backcompat

### DIFF
--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/api/v1/views.py
+++ b/completion/api/v1/views.py
@@ -14,8 +14,18 @@ from rest_framework.response import Response
 from rest_framework import permissions
 from rest_framework import status
 
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+# pylint: disable=ungrouped-imports
+try:
+    from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+except ImportError:
+    from edx_rest_framework_extensions.authentication import JwtAuthentication
+
+try:
+    from edx_rest_framework_extensions.auth.session.authentication import SessionAuthenticationAllowInactiveUser
+except ImportError:
+    from edx_rest_framework_extensions.authentication import SessionAuthenticationAllowInactiveUser
+# pylint: enable=ungrouped-imports
+
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from opaque_keys import InvalidKeyError
 from six import text_type

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,6 +4,6 @@ Django>=1.8,<2.0          # Web application framework
 django-model-utils        # Provides TimeStampedModel abstract base class
 djangorestframework>=3.2.0,<3.7.0  # REST API framework
 edx-opaque-keys[django]   # Create and introspect course and xblock identities
-edx-drf-extensions>=2.0.0,<3.0.0 # Provides JWT authentication
+edx-drf-extensions>=1.11.0,<3.0.0 # Provides JWT authentication
 pytz                      # Time zone support
 XBlock>=1.2.2             # Courseware component architecture


### PR DESCRIPTION
**Description:** 

The latest version of edx-drf-extensions is not compatible with ginkgo.  Adding conditional backwards-compatibility imports makes it possible for ginkgo to use the latest version of this app without extensive modifications.

**JIRA:** BB-1060

**Dependencies:** TBA. (There will be PRs against edx/edx-platform and edx-solutions/edx-platform to verify that this works properly.)
 

**Installation instructions:** N/A

**Testing instructions:** Install this into edx-platform/master and ginkgo (on edx-solutions branch, and verify that completion endpoints are usable on both. 

**Reviewers:**
- [ ] @xitij2000 
- [ ] @doctoryes ? 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed
- [ ] PR author is listed in AUTHORS

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
