### PR TITLE
Upgrade pip-tools and make upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	tox -e docs
 	$(BROWSER) docs/_build/html/index.html
 
+upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	pip install -q pip-tools
 	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,7 +10,7 @@ astroid==1.5.3            # via pylint, pylint-celery
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 backports.functools-lru-cache==1.5  # via astroid, caniusepython3, isort, pylint
-backports.os==0.1.1       # via fs, path.py
+backports.os==0.1.1       # via fs
 caniusepython3==7.0.0
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
@@ -26,7 +26,7 @@ django-model-utils==3.1.2
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.2
+djangorestframework==3.9.3
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.2.0
 edx-i18n-tools==0.4.8
@@ -45,21 +45,21 @@ idna==2.8                 # via requests
 importlib-metadata==0.9   # via path.py
 inflect==2.1.0            # via jinja2-pluralize
 ipaddress==1.0.22         # via faker
-isort==4.3.17
+isort==4.3.18
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.10.1            # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.3.1  # via astroid
 lxml==4.3.3               # via xblock
 markupsafe==1.1.1         # via jinja2, xblock
 mccabe==0.6.1             # via pylint
-mock==2.0.0
+mock==3.0.3
 more-itertools==5.0.0     # via pytest
 newrelic==4.18.0.118      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.3           # via importlib-metadata, pytest, pytest-django
-pbr==5.1.3                # via mock, stevedore
-pip-tools==3.6.0
+pbr==5.2.0                # via stevedore
+pip-tools==3.6.1
 pluggy==0.9.0             # via pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
@@ -76,7 +76,7 @@ pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
 pyparsing==2.4.0          # via packaging
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest==4.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via edx-drf-extensions, faker, freezegun, xblock
@@ -87,7 +87,7 @@ rest-condition==1.0.3     # via edx-drf-extensions
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.12.0               # via astroid, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pip-tools, pydocstyle, pyjwkest, pylint, pytest, python-dateutil, singledispatch, stevedore, tox, xblock
+six==1.12.0               # via astroid, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, packaging, pathlib2, pip-tools, pydocstyle, pyjwkest, pylint, pytest, python-dateutil, singledispatch, stevedore, tox, xblock
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
@@ -95,10 +95,10 @@ toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox==3.9.0
 typing==3.6.6             # via fs
-urllib3==1.24.2           # via requests
-virtualenv==16.4.3        # via tox
+urllib3==1.24.3           # via requests
+virtualenv==16.5.0        # via tox
 web-fragments==0.3.0      # via xblock
 webob==1.8.5              # via xblock
 wrapt==1.11.1             # via astroid
 xblock==1.2.2
-zipp==0.3.3               # via importlib-metadata
+zipp==0.4.0               # via importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -4,11 +4,9 @@
 #
 #    make upgrade
 #
-alabaster==0.7.12         # via sphinx
 appdirs==1.4.3            # via fs
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
-babel==2.6.0              # via sphinx
 backports.os==0.1.1       # via fs
 bleach==3.1.0             # via readme-renderer
 certifi==2019.3.9         # via requests
@@ -19,9 +17,9 @@ django-model-utils==3.1.2
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.2
+djangorestframework==3.9.3
 doc8==0.8.0
-docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint, sphinx
+docutils==0.14            # via doc8, readme-renderer, restructuredtext-lint
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.2.0
 edx-opaque-keys[django]==0.4.4
@@ -34,46 +32,40 @@ fs==2.4.4                 # via xblock
 funcsigs==1.0.2           # via mock, pytest
 future==0.17.1            # via backports.os, pyjwkest
 idna==2.8                 # via requests
-imagesize==1.1.0          # via sphinx
 ipaddress==1.0.22         # via faker
-jinja2==2.10.1            # via sphinx
 lxml==4.3.3               # via xblock
-markupsafe==1.1.1         # via jinja2, xblock
-mock==2.0.0
+markupsafe==1.1.1         # via xblock
+mock==3.0.3
 more-itertools==5.0.0     # via pytest
 newrelic==4.18.0.118      # via edx-django-utils
-packaging==19.0           # via sphinx
 pathlib2==2.3.3           # via pytest, pytest-django
-pbr==5.1.3                # via mock, stevedore
+pbr==5.2.0                # via stevedore
 pluggy==0.9.0             # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest
 pycryptodomex==3.8.1      # via pyjwkest
-pygments==2.3.1           # via readme-renderer, sphinx
+pygments==2.3.1           # via readme-renderer
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt
 pymongo==3.8.0            # via edx-opaque-keys
-pyparsing==2.4.0          # via packaging
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest==4.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via edx-drf-extensions, faker, freezegun, xblock
 pytz==2019.1
 pyyaml==5.1               # via xblock
 readme-renderer==24.0
-requests==2.21.0          # via edx-drf-extensions, pyjwkest, sphinx
+requests==2.21.0          # via edx-drf-extensions, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
 restructuredtext-lint==1.3.0  # via doc8
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.12.0               # via bleach, doc8, edx-drf-extensions, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pyjwkest, pytest, python-dateutil, readme-renderer, sphinx, stevedore, xblock
-snowballstemmer==1.2.1    # via sphinx
+six==1.12.0               # via bleach, doc8, edx-drf-extensions, edx-opaque-keys, edx-sphinx-theme, faker, freezegun, fs, mock, pathlib2, pyjwkest, pytest, python-dateutil, readme-renderer, stevedore, xblock
 sphinx==1.8.5
-sphinxcontrib-websupport==1.1.0  # via sphinx
 stevedore==1.30.1         # via doc8, edx-opaque-keys
 text-unidecode==1.2       # via faker
-typing==3.6.6             # via fs, sphinx
-urllib3==1.24.2           # via requests
+typing==3.6.6             # via fs
+urllib3==1.24.3           # via requests
 web-fragments==0.3.0      # via xblock
 webencodings==0.5.1       # via bleach
 webob==1.8.5              # via xblock

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -24,7 +24,7 @@ django-model-utils==3.1.2
 django-waffle==0.16.0     # via edx-django-utils, edx-drf-extensions
 django==1.11.20
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
-djangorestframework==3.9.2
+djangorestframework==3.9.3
 edx-django-utils==1.0.3   # via edx-drf-extensions
 edx-drf-extensions==2.2.0
 edx-lint==1.1.2
@@ -39,17 +39,17 @@ future==0.17.1            # via backports.os, pyjwkest
 futures==3.2.0 ; python_version == "2.7"  # via caniusepython3, isort
 idna==2.8                 # via requests
 ipaddress==1.0.22         # via faker
-isort==4.3.17
+isort==4.3.18
 lazy-object-proxy==1.3.1  # via astroid
 lxml==4.3.3               # via xblock
 markupsafe==1.1.1         # via xblock
 mccabe==0.6.1             # via pylint
-mock==2.0.0
+mock==3.0.3
 more-itertools==5.0.0     # via pytest
 newrelic==4.18.0.118      # via edx-django-utils
 packaging==19.0           # via caniusepython3
 pathlib2==2.3.3           # via pytest, pytest-django
-pbr==5.1.3                # via mock, stevedore
+pbr==5.2.0                # via stevedore
 pluggy==0.9.0             # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest
@@ -64,7 +64,7 @@ pylint-plugin-utils==0.5  # via pylint-celery, pylint-django
 pylint==1.7.6             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.8.0            # via edx-opaque-keys
 pyparsing==2.4.0          # via packaging
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest==4.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via edx-drf-extensions, faker, freezegun, xblock
@@ -75,12 +75,12 @@ rest-condition==1.0.3     # via edx-drf-extensions
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.12.0               # via astroid, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, packaging, pathlib2, pydocstyle, pyjwkest, pylint, pytest, python-dateutil, singledispatch, stevedore, xblock
+six==1.12.0               # via astroid, edx-drf-extensions, edx-lint, edx-opaque-keys, faker, freezegun, fs, mock, packaging, pathlib2, pydocstyle, pyjwkest, pylint, pytest, python-dateutil, singledispatch, stevedore, xblock
 snowballstemmer==1.2.1    # via pydocstyle
 stevedore==1.30.1         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
 typing==3.6.6             # via fs
-urllib3==1.24.2           # via requests
+urllib3==1.24.3           # via requests
 web-fragments==0.3.0      # via xblock
 webob==1.8.5              # via xblock
 wrapt==1.11.1             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -29,11 +29,11 @@ idna==2.8                 # via requests
 ipaddress==1.0.22         # via faker
 lxml==4.3.3               # via xblock
 markupsafe==1.1.1         # via xblock
-mock==2.0.0
+mock==3.0.3
 more-itertools==5.0.0     # via pytest
 newrelic==4.18.0.118      # via edx-django-utils
 pathlib2==2.3.3           # via pytest, pytest-django
-pbr==5.1.3                # via mock, stevedore
+pbr==5.2.0                # via stevedore
 pluggy==0.9.0             # via pytest
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions
 py==1.8.0                 # via pytest
@@ -41,7 +41,7 @@ pycryptodomex==3.8.1      # via pyjwkest
 pyjwkest==1.3.2           # via edx-drf-extensions
 pyjwt==1.7.1              # via djangorestframework-jwt
 pymongo==3.8.0            # via edx-opaque-keys
-pytest-cov==2.6.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest==4.4.1             # via pytest-cov, pytest-django
 python-dateutil==2.8.0    # via edx-drf-extensions, faker, freezegun, xblock
@@ -51,11 +51,11 @@ requests==2.21.0          # via edx-drf-extensions, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
 scandir==1.10.0           # via pathlib2
 semantic-version==2.6.0   # via edx-drf-extensions
-six==1.12.0               # via edx-drf-extensions, edx-opaque-keys, faker, freezegun, fs, mock, more-itertools, pathlib2, pyjwkest, pytest, python-dateutil, stevedore, xblock
+six==1.12.0               # via edx-drf-extensions, edx-opaque-keys, faker, freezegun, fs, mock, pathlib2, pyjwkest, pytest, python-dateutil, stevedore, xblock
 stevedore==1.30.1         # via edx-opaque-keys
 text-unidecode==1.2       # via faker
 typing==3.6.6             # via fs
-urllib3==1.24.2           # via requests
+urllib3==1.24.3           # via requests
 web-fragments==0.3.0      # via xblock
 webob==1.8.5              # via xblock
 xblock==1.2.2

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -17,5 +17,5 @@ six==1.12.0               # via tox
 toml==0.10.0              # via tox
 tox-battery==0.5.1
 tox==3.9.0
-urllib3==1.24.2           # via requests
-virtualenv==16.4.3        # via tox
+urllib3==1.24.3           # via requests
+virtualenv==16.5.0        # via tox


### PR DESCRIPTION
Similar to this PR: edx/devstack#401 , a manual upgrade of pip-tools to 3.6.1 was required to fix the auto dependency PR's

**Description:** Describe in a couple of sentence what this PR adds

**JIRA:** Link to JIRA ticket

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:** List testing instructions

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
