### PR TITLE
Change completion API to work with any learning context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.0.0] - 2019-10-04
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Support tracking completion of XBlocks in any "learning context", such as in
+  a content library, and not just in courses. To keep the code clean, this has
+  been done as a **breaking change** to the python API. (The API has been
+  simplified so that it's generally only necessary to pass in a block key /
+  usage key rather than block key + course key.) The REST API is unchanged.
+
 [2.1.1] - 2019-10-21
 --------------------
 * Updated credentials for PyPI deployment via token.
@@ -24,18 +32,18 @@ Unreleased
   the old implementation allowed subtle bugs under Python 2.7 but triggers an immediate error under 3.5.
 
 [2.0.0] - 2019-04-23
---------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Unpin django-rest-framework requirements. This is a potentially **breaking change** if people were
   relying on this package to ensure the correct version of djangorestframework was being installed.
 * Remove the AUTHORS file and references to it.
 
 [1.0.2] - 2019-03-11
---------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Fix the 403 error occurring for completion-batch API for requests coming from the iOS devices
 
 [1.0.0] - 2018-10-16
---------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Updated edx-drf-extensions imports. Completion will no longer work with
   outdated versions of edx-drf-extensions.
 

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,12 @@ This repository provides a Django model `BlockCompletion` that is intended to be
 provides various handlers and services for the recording of completion data.  It also provides a DRF API for submitting
 completion data in batches.
 
+Enabling in the LMS
+-------------------
+By default, the Open edX LMS does not use this library. To turn it on, go to http://localhost:18000/admin/waffle/switch/ (substitute your LMS URL for http://localhost:18000/), and add a new switch with Name ``completion.enable_completion_tracking`` and Active selected.
+
+See `Completion Tool <https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/completion.html>`_ in the Open edX documentation for details on what will happen once enabled.
+
 License
 -------
 
@@ -61,6 +67,8 @@ Note: When you see "from inside the lms" below, it means that you've run ``make 
     virtualenv completion-env
     source completion-env/bin/activate
     make install
+
+#. Don't forget to enable the waffle switch as described above in "Enabling in the LMS"
 
 #. That's it!  In order to simulate a given tox environment ``(django18, django111, quality)``, run ``tox -e <env>`` for the env in question.  If you want to run ``pytest`` directly::
 

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '2.1.1'
+__version__ = '3.0.0'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/exceptions.py
+++ b/completion/exceptions.py
@@ -10,6 +10,6 @@ class UnavailableCompletionData(Exception):
     completion data from BlockCompletion.
     '''
 
-    def __init__(self, course_key):
+    def __init__(self, context_key):
         Exception.__init__(
-            self, "The learner does not have completion data within course {}".format(course_key))
+            self, "The learner does not have completion data within learning context {}".format(context_key))

--- a/completion/handlers.py
+++ b/completion/handlers.py
@@ -2,14 +2,18 @@
 Signal handlers to trigger completion updates.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
+import logging
 
 from django.contrib.auth.models import User
-from opaque_keys.edx.keys import CourseKey, UsageKey
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import LearningContextKey, UsageKey
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 
 from . import waffle
 from .models import BlockCompletion
+
+log = logging.getLogger(__name__)
 
 
 def scorable_block_completion(sender, **kwargs):  # pylint: disable=unused-argument
@@ -18,8 +22,18 @@ def scorable_block_completion(sender, **kwargs):  # pylint: disable=unused-argum
     """
     if not waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
         return
-    course_key = CourseKey.from_string(kwargs['course_id'])
-    block_key = UsageKey.from_string(kwargs['usage_id'])
+    try:
+        block_key = UsageKey.from_string(kwargs['usage_id'])
+    except InvalidKeyError:
+        log.exception("Unable to parse XBlock usage_id for completion: %s", block_key)
+        return
+
+    if block_key.context_key.is_course and block_key.context_key.run is None:
+        # In the case of old mongo courses, the context_key cannot be derived
+        # from the block key alone since it will be missing run info:
+        course_key_with_run = LearningContextKey.from_string(kwargs['course_id'])
+        block_key = block_key.replace(course_key=course_key_with_run)
+
     block_cls = XBlock.load_class(block_key.block_type)
     if XBlockCompletionMode.get_mode(block_cls) != XBlockCompletionMode.COMPLETABLE:
         return
@@ -33,7 +47,6 @@ def scorable_block_completion(sender, **kwargs):  # pylint: disable=unused-argum
     if not kwargs.get('grader_response'):
         BlockCompletion.objects.submit_completion(
             user=user,
-            course_key=course_key,
             block_key=block_key,
             completion=completion,
         )

--- a/completion/migrations/0003_learning_context.py
+++ b/completion/migrations/0003_learning_context.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Changes completion to track blocks for any learning context,
+# and not just for courses.
+#
+# This migration does not produce any database-level changes. You can verify
+# this with: ./manage.py lms sqlmigrate completion 0003
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations
+import opaque_keys.edx.django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('completion', '0002_auto_20180125_1510'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='blockcompletion',
+            name='course_key',
+            field=opaque_keys.edx.django.models.LearningContextKeyField(db_column='course_key', max_length=255),
+            preserve_default=False,
+        ),
+        migrations.RenameField(
+            model_name='blockcompletion',
+            old_name='course_key',
+            new_name='context_key',
+        ),
+        migrations.AlterUniqueTogether(
+            name='blockcompletion',
+            unique_together=set([('context_key', 'block_key', 'user')]),
+        ),
+        migrations.AlterIndexTogether(
+            name='blockcompletion',
+            index_together=set([('user', 'context_key', 'modified'), ('context_key', 'block_type', 'user')]),
+        ),
+    ]

--- a/completion/test_utils.py
+++ b/completion/test_utils.py
@@ -10,23 +10,22 @@ from django.contrib.auth.models import User
 import factory
 from factory.django import DjangoModelFactory
 import mock
-from opaque_keys.edx.keys import UsageKey, CourseKey
+from opaque_keys.edx.keys import UsageKey
 from pytz import UTC
 
 from . import waffle
 from .models import BlockCompletion
 
 
-def submit_completions_for_testing(user, course_key, block_keys):
+def submit_completions_for_testing(user, block_keys):
     '''
-    Allows tests to submit completion data for a given user, course_key, and
+    Allows tests to submit completion data for a given user and
     list of block_keys. The method completes the "block_keys" by adding them
     to the BlockCompletion model.
     '''
     for idx, block_key in enumerate(block_keys):
         BlockCompletion.objects.submit_completion(
             user=user,
-            course_key=course_key,
             block_key=block_key,
             completion=1.0 - (0.2 * idx),
         )
@@ -92,7 +91,7 @@ class CompletionSetUpMixin(object):
     def setUp(self):
         super(CompletionSetUpMixin, self).setUp()
         self.block_key = UsageKey.from_string('block-v1:edx+test+run+type@video+block@doggos')
-        self.course_key = CourseKey.from_string('course-v1:edx+test+run')
+        self.context_key = self.block_key.context_key
         self.user = UserFactory()
 
     def set_up_completion(self):
@@ -101,7 +100,7 @@ class CompletionSetUpMixin(object):
         """
         self.completion = BlockCompletion.objects.create(
             user=self.user,
-            course_key=self.block_key.course_key,
+            context_key=self.block_key.context_key,
             block_type=self.block_key.block_type,
             block_key=self.block_key,
             completion=0.5,

--- a/completion/tests/test_utilities.py
+++ b/completion/tests/test_utilities.py
@@ -9,7 +9,7 @@ from opaque_keys.edx.keys import CourseKey
 from six import text_type
 
 from ..exceptions import UnavailableCompletionData
-from ..utilities import get_key_to_last_completed_course_block
+from ..utilities import get_key_to_last_completed_block
 from ..test_utils import UserFactory, CompletionSetUpMixin, submit_completions_for_testing
 
 
@@ -28,10 +28,10 @@ class TestCompletionUtilities(CompletionSetUpMixin, TestCase):
             self.course_key.make_usage_key('video', text_type(number))
             for number in range(5)
         ]
-        submit_completions_for_testing(self.user, self.course_key, self.block_keys)
+        submit_completions_for_testing(self.user, self.block_keys)
 
-    def test_can_get_key_to_last_completed_course_block(self):
-        last_block_key = get_key_to_last_completed_course_block(
+    def test_can_get_key_to_last_completed_block(self):
+        last_block_key = get_key_to_last_completed_block(
             self.user,
             self.course_key
         )
@@ -46,4 +46,4 @@ class TestCompletionUtilities(CompletionSetUpMixin, TestCase):
         course_key = CourseKey.from_string("edX/NotACourse/2049_T2")
 
         with self.assertRaises(UnavailableCompletionData):
-            get_key_to_last_completed_course_block(self.user, course_key)
+            get_key_to_last_completed_block(self.user, course_key)

--- a/completion/utilities.py
+++ b/completion/utilities.py
@@ -10,9 +10,10 @@ from .exceptions import UnavailableCompletionData
 from .models import BlockCompletion
 
 
-def get_key_to_last_completed_course_block(user, course_key):
+def get_key_to_last_completed_block(user, context_key):
     """
-    Returns the last block a "user" completed in a course (stated as "course_key").
+    Returns the last block a "user" completed in a learning context such as a
+    specific course (stated as "context_key").
 
     raises UnavailableCompletionData when the user has not completed blocks in
     the course.
@@ -21,9 +22,9 @@ def get_key_to_last_completed_course_block(user, course_key):
     disabled.
     """
 
-    last_completed_block = BlockCompletion.get_latest_block_completed(user, course_key)
+    last_completed_block = BlockCompletion.get_latest_block_completed(user, context_key)
 
     if last_completed_block is not None:
         return last_completed_block.block_key
 
-    raise UnavailableCompletionData(course_key)
+    raise UnavailableCompletionData(context_key)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,7 +31,7 @@ edx-django-utils==2.0.0   # via edx-drf-extensions
 edx-drf-extensions==2.4.0
 edx-i18n-tools==0.4.8
 edx-lint==1.3.0
-edx-opaque-keys[django]==1.0.1
+edx-opaque-keys[django]==2.0.0
 enum34==1.1.6             # via astroid, fs
 factory-boy==2.12.0
 faker==2.0.0              # via factory-boy

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -26,7 +26,7 @@ doc8==0.8.0
 docutils==0.15.2          # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-django-utils==2.0.0   # via edx-drf-extensions
 edx-drf-extensions==2.4.0
-edx-opaque-keys[django]==1.0.1
+edx-opaque-keys[django]==2.0.0
 edx-sphinx-theme==1.5.0
 enum34==1.1.6             # via fs
 factory-boy==2.12.0

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -29,7 +29,7 @@ djangorestframework==3.9.4
 edx-django-utils==2.0.0   # via edx-drf-extensions
 edx-drf-extensions==2.4.0
 edx-lint==1.3.0
-edx-opaque-keys[django]==1.0.1
+edx-opaque-keys[django]==2.0.0
 enum34==1.1.6             # via astroid, fs
 factory-boy==2.12.0
 faker==2.0.0              # via factory-boy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,7 @@ django-waffle==0.17.0     # via edx-django-utils, edx-drf-extensions
 djangorestframework-jwt==1.11.0  # via edx-drf-extensions
 edx-django-utils==2.0.0   # via edx-drf-extensions
 edx-drf-extensions==2.4.0
-edx-opaque-keys[django]==1.0.1
+edx-opaque-keys[django]==2.0.0
 enum34==1.1.6             # via fs
 factory-boy==2.12.0
 faker==2.0.0              # via factory-boy


### PR DESCRIPTION
**Description:** This changes the python API of edx-completion to use the more generic concept of "learning context" instead of courses. This allows the app to track the completion of XBlocks that are in content libraries or other future learning contexts and not just courses.

I decided to do a clean and backwards-incompatible change to the entire python API rather than trying to preserve the existing API in a backwards-compatible way because this python API is relatively new, is only really consumed by edx-platform which I'll update at the same time, and because having a mix of "course_key" and "context_key" throughout the code was getting a bit messy.

While I was at it, I simplified the API, removing the need to specify a `course_key` and a `block_key`, as the course_key/context_key can be trivially derived from the block_key and the only exception is for old_mongo which is deprecated and can still be supported with these changes as long as the client sends the right block_key format.

This includes a data migration but it produces no actual database changes.

I have kept the REST API unchanged since changes to REST APIs are more problematic, especially if used by deployed mobile apps.

https://github.com/edx/edx-platform/pull/21913 is the related edx-platform PR that uses these changes.

I am not planning to update [openedx-completion-aggregator](https://github.com/open-craft/openedx-completion-aggregator/) for now, since it's not in use in production by anyone using a current release of Open edX as far as I know. ("Yonkers" uses it on an old release.)

Without this change, we were seeing these errors on courses.edx.org:

```
File "/edx/app/edxapp/edx-platform/openedx/core/djangoapps/xblock/runtime/runtime.py", line 163, in handle_grade_event grader_response=event.get('grader_response')
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 193, in send for receiver in self._live_receivers(sender)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/signals/handlers.py", line 181, in score_published_handler grader_response=kwargs.get('grader_response', False)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 193, in send for receiver in self._live_receivers(sender)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/grades/signals/handlers.py", line 212, in problem_raw_score_changed_handler grader_response=kwargs.get('grader_response', False)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 193, in send for receiver in self._live_receivers(sender)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/completion/handlers.py", line 21, in scorable_block_completion course_key = CourseKey.from_string(kwargs['course_id'])
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/opaque_keys/init_.py", line 202, in from_string return cls.deprecated_fallback._from_deprecated_string(serialized)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/opaque_keys/edx/locator.py", line 390, in _from_deprecated_string raise InvalidKeyError(cls, serialized
```

**Dependencies:** this is a dependency of https://github.com/edx/edx-platform/pull/21913

**Installation instructions:** Nothing different.

**Testing instructions:**

Clone to `src/completion`

Run the tests on devstack from `make lms-shell`:
```
pip install -e /edx/src/completion
cd /edx/src/completion
pytest completion/tests/

cd /edx/app/edxapp/edx-platform
python -Wd -m pytest --ds=lms.envs.test openedx/tests/completion_integration/
```

**Reviewers:**
- [ ] TBD

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped to 3.0.0 - backwards incompatible change
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
