### PR TITLE
Don't try to put XBlocks in a set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+
+[2.1.0] - 2019-10-18
+--------------------
+* Switch blocks_to_mark_complete_on_view() to return a list of XBlocks instead of a set.  Many XBlocks aren't hashable;
+  the old implementation allowed subtle bugs under Python 2.7 but triggers an immediate error under 3.5.
+
 [2.0.0] - 2019-04-23
 --------------------
 * Unpin django-rest-framework requirements. This is a potentially **breaking change** if people were

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -5,6 +5,6 @@ Completion App
 from __future__ import unicode_literals
 
 
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/services.py
+++ b/completion/services.py
@@ -113,11 +113,11 @@ class CompletionService(object):
 
     def blocks_to_mark_complete_on_view(self, blocks):
         """
-        Returns a set of blocks which should be marked complete on view and haven't been yet.
+        Returns a list of blocks which should be marked complete on view and haven't been yet.
         """
-        blocks = {block for block in blocks if self.can_mark_block_complete_on_view(block)}
+        blocks = [block for block in blocks if self.can_mark_block_complete_on_view(block)]
         completions = self.get_completions({block.location for block in blocks})
-        return {block for block in blocks if completions.get(block.location, 0) < 1.0}
+        return [block for block in blocks if completions.get(block.location, 0) < 1.0]
 
     def submit_group_completion(self, block_key, completion, users=None, user_ids=None):
         """

--- a/completion/tests/test_services.py
+++ b/completion/tests/test_services.py
@@ -164,17 +164,17 @@ class CompletionServiceTestCase(CompletionSetUpMixin, TestCase):
         aggregator_block.location = UsageKey.from_string("i4x://edX/100/a/3").replace(course_key=self.course_key)
         aggregator_block.completion_mode = XBlockCompletionMode.AGGREGATOR
 
-        self.assertSetEqual(self.completion_service.blocks_to_mark_complete_on_view({}), set())
+        self.assertEqual(self.completion_service.blocks_to_mark_complete_on_view([]), [])
 
-        self.assertSetEqual(
-            self.completion_service.blocks_to_mark_complete_on_view({aggregator_block}), set()
+        self.assertEqual(
+            self.completion_service.blocks_to_mark_complete_on_view([aggregator_block]), []
         )
 
-        self.assertSetEqual(
+        self.assertEqual(
             self.completion_service.blocks_to_mark_complete_on_view(
-                {completable_block_1, completable_block_2, aggregator_block}
+                [completable_block_1, completable_block_2, aggregator_block]
             ),
-            {completable_block_1, completable_block_2}
+            [completable_block_1, completable_block_2]
         )
 
         BlockCompletion.objects.submit_completion(
@@ -184,11 +184,11 @@ class CompletionServiceTestCase(CompletionSetUpMixin, TestCase):
             completion=1.0
         )
 
-        self.assertSetEqual(
+        self.assertEqual(
             self.completion_service.blocks_to_mark_complete_on_view(
-                {completable_block_1, completable_block_2, aggregator_block}
+                [completable_block_1, completable_block_2, aggregator_block]
             ),
-            {completable_block_1}
+            [completable_block_1]
         )
 
         BlockCompletion.objects.submit_completion(
@@ -198,11 +198,11 @@ class CompletionServiceTestCase(CompletionSetUpMixin, TestCase):
             completion=1.0
         )
 
-        self.assertSetEqual(
+        self.assertEqual(
             self.completion_service.blocks_to_mark_complete_on_view(
-                {completable_block_1, completable_block_2, aggregator_block}
+                [completable_block_1, completable_block_2, aggregator_block]
             ),
-            set()
+            []
         )
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -59,7 +59,7 @@ packaging==19.1           # via caniusepython3, pytest, tox
 path.py==11.5.2           # via edx-i18n-tools
 pathlib2==2.3.4           # via importlib-metadata, pytest, pytest-django
 pbr==5.4.2                # via stevedore
-pip-tools==4.0.0
+pip-tools==4.2.0
 pluggy==0.12.0            # via pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils, edx-drf-extensions

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ def get_version(*file_paths):
     Extract the version string from the file at the given relative path fragments.
     """
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
-    version_file = open(filename).read()
+    with open(filename) as f:
+        version_file = f.read()
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)
     if version_match:


### PR DESCRIPTION
**Description:** Fix an error under Python 3 (and subtle bug under 2.7) involving non-hashable XBlocks.  Many XBlocks are non-hashable because they inherit a custom `__eq__` which depends on the value of the block's attributes rather than the object's identity.  Python 2.7 depends on the author manually flagging the class as non-hashable in this case (which we didn't), but Python 3 detects it and throws errors accordingly.  This was causing at least 4 bok-choy tests to fail in edx-platform.

**JIRA:** [BOM-957](https://openedx.atlassian.net/browse/BOM-957)

**Reviewers:**
- [ ] @iloveagent57 
- [ ] @feanil 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
