### PR TITLE
AA-220: Have a vertical check all leaf children

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,16 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.2.2] - 2020-06-30
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Adding recursive lookup for children of a vertical to the `vertical_is_complete` method in services.py.
+
+  * This was added because verticals containing children that had their own children were not being properly marked
+    as complete. Since the vertical was only looking one layer deep, it was possible to have children lower in the tree
+    incomplete, but the vertical would still be marked as complete. Now it looks at all leaves under the vertical.
+
 [3.1.1] - 2020-02-24
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Remove unnecessary constraint for edx-drf-extensions<3.0.0
 
 [3.1.0] - 2020-02-18

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '3.2.1'
+__version__ = '3.2.2'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
We encountered an issue where a vertical was being marked complete
when it had a content library as a child because the content library
was being marked as complete and none of the actual problems in the
library were being checked. This now will check those children

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
