### PR TITLE
AA-220: Bug fix for get_user_children

### DIFF
--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '3.2.2'
+__version__ = '3.2.3'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
**Description:** Fixing a bug regarding the improper checking of discussion. Also updating the function to look explicitly for each type of children under a vertical after experiencing difficulties with other block types. This will now only account for library content blocks that have children that can be completed.

https://github.com/edx/edx-platform/pull/24365

**Reviewers:**
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
