### PR TITLE
Pin drf-jwt to 1.15

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,10 @@
 
 Django < 2.3
 
+# latest version drf-jwt==1.16.2 is causing failures in ecom, platform and discovery. 
+# So avoiding that until fix that issue.
+drf-jwt<1.15.0
+
 # Requires: Python >=3.6
 mock<4.0.0
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,25 +9,23 @@ astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 bleach==3.1.5             # via readme-renderer
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint, pip-tools
-coverage==5.1             # via pytest-cov
-cryptography==2.9.2       # via pyjwt
+coverage==5.2             # via pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
 diff-cover==3.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via virtualenv
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.in, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via readme-renderer
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==1.4.1           # via -r requirements/dev.in, -r requirements/quality.in
+edx-lint==1.5.0           # via -r requirements/dev.in, -r requirements/quality.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/base.in, edx-drf-extensions
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.1              # via factory-boy
@@ -36,8 +34,8 @@ freezegun==0.3.15         # via -r requirements/test.in
 fs==2.4.11                # via xblock
 future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==2.0.1  # via virtualenv
+importlib-metadata==1.7.0  # via inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
@@ -61,16 +59,15 @@ polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via edx-django-utils
 py==1.9.0                 # via pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.in
-pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via diff-cover, readme-renderer
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt
+pyjwt==1.7.1              # via drf-jwt
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
@@ -84,7 +81,7 @@ requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via edx-drf-extensions, pyjwkest, requests-toolbelt, twine
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via astroid, bleach, cryptography, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, freezegun, fs, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, readme-renderer, stevedore, tox, virtualenv, xblock
+six==1.15.0               # via astroid, bleach, diff-cover, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, freezegun, fs, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, readme-renderer, stevedore, tox, virtualenv, xblock
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
@@ -97,7 +94,7 @@ twine==1.15.0             # via -c requirements/constraints.txt, -r requirements
 typed-ast==1.4.1          # via astroid
 typing==3.7.4.1           # via fs
 urllib3==1.25.9           # via requests
-virtualenv==20.0.25       # via tox
+virtualenv==20.0.26       # via tox
 wcwidth==0.2.5            # via pytest
 web-fragments==0.3.2      # via xblock
 webencodings==0.5.1       # via bleach

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -9,18 +9,16 @@ appdirs==1.4.4            # via fs
 attrs==19.3.0             # via pytest
 babel==2.8.0              # via sphinx
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via doc8, requests
-coverage==5.1             # via pytest-cov
-cryptography==2.9.2       # via pyjwt
+coverage==5.2             # via pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.in, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, restructuredtext-lint, sphinx
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/base.in, edx-drf-extensions
@@ -45,11 +43,10 @@ pbr==5.4.5                # via stevedore
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
 py==1.9.0                 # via pytest
-pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pygments==2.6.1           # via doc8, sphinx
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt
+pyjwt==1.7.1              # via drf-jwt
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
@@ -62,9 +59,9 @@ requests==2.24.0          # via edx-drf-extensions, pyjwkest, sphinx
 rest-condition==1.0.3     # via edx-drf-extensions
 restructuredtext-lint==1.3.1  # via doc8
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via cryptography, doc8, edx-drf-extensions, edx-opaque-keys, edx-sphinx-theme, freezegun, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, xblock
+six==1.15.0               # via doc8, edx-drf-extensions, edx-opaque-keys, edx-sphinx-theme, freezegun, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, xblock
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.1.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,22 +9,20 @@ astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 bleach==3.1.5             # via readme-renderer
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-coverage==5.1             # via pytest-cov
-cryptography==2.9.2       # via pyjwt
+coverage==5.2             # via pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
 djangorestframework==3.11.0  # via -r requirements/base.in, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via readme-renderer
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
-edx-lint==1.4.1           # via -r requirements/quality.in
+edx-lint==1.5.0           # via -r requirements/quality.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/base.in, edx-drf-extensions
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.1              # via factory-boy
@@ -49,16 +47,15 @@ pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via -r requirements/quality.in
-pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pygments==2.6.1           # via readme-renderer
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt
+pyjwt==1.7.1              # via drf-jwt
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
@@ -72,7 +69,7 @@ requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via edx-drf-extensions, pyjwkest, requests-toolbelt, twine
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via astroid, bleach, cryptography, edx-drf-extensions, edx-lint, edx-opaque-keys, freezegun, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, stevedore, xblock
+six==1.15.0               # via astroid, bleach, edx-drf-extensions, edx-lint, edx-opaque-keys, freezegun, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, stevedore, xblock
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,14 +7,12 @@
 appdirs==1.4.4            # via fs
 attrs==19.3.0             # via pytest
 certifi==2020.6.20        # via requests
-cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
-coverage==5.1             # via pytest-cov
-cryptography==2.9.2       # via pyjwt
+coverage==5.2             # via pytest-cov
 ddt==1.4.1                # via -r requirements/test.in
 django-model-utils==4.0.0  # via -r requirements/base.in
 django-waffle==1.0.0      # via edx-django-utils, edx-drf-extensions
-drf-jwt==1.16.2           # via edx-drf-extensions
+drf-jwt==1.14.0           # via -c requirements/constraints.txt, edx-drf-extensions
 edx-django-utils==3.2.3   # via edx-drf-extensions
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
 edx-opaque-keys[django]==2.1.0  # via -r requirements/base.in, edx-drf-extensions
@@ -36,10 +34,9 @@ pbr==5.4.5                # via stevedore
 pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via edx-django-utils
 py==1.9.0                 # via pytest
-pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt[crypto]==1.7.1      # via drf-jwt
+pyjwt==1.7.1              # via drf-jwt
 pymongo==3.10.1           # via edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
@@ -51,7 +48,7 @@ pyyaml==5.3.1             # via xblock
 requests==2.24.0          # via edx-drf-extensions, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-six==1.15.0               # via cryptography, edx-drf-extensions, edx-opaque-keys, freezegun, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, xblock
+six==1.15.0               # via edx-drf-extensions, edx-opaque-keys, freezegun, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, xblock
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 text-unidecode==1.3       # via faker

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -8,12 +8,12 @@ appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 codecov==2.1.7            # via -r requirements/travis.in
-coverage==5.1             # via codecov
+coverage==5.2             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via importlib-resources, pluggy, tox, virtualenv
-importlib-resources==2.0.1  # via virtualenv
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/travis.in
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -25,5 +25,5 @@ toml==0.10.1              # via tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/travis.in
 tox==3.16.1               # via -r requirements/travis.in, tox-battery
 urllib3==1.25.9           # via requests
-virtualenv==20.0.25       # via tox
+virtualenv==20.0.26       # via tox
 zipp==1.2.0               # via -c requirements/constraints.txt, importlib-metadata, importlib-resources


### PR DESCRIPTION
Latest version drf-jwt==1.16.2 is causing failures in ecom, platform and discovery.
So avoiding that until fix that issue.

