### PR TITLE
Look before we leap to access completable children

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.2.4] - 2020-07-21
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fix AttributeError raised by `vertical_is_complete`.
+  * by ensuring `get_completable_children` doesn't return null
+
 [3.2.3] - 2020-07-01
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Updated the children lookup for `vertical_is_complete` to utilize the XBlockCompletion model. There are

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '3.2.3'
+__version__ = '3.2.4'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/services.py
+++ b/completion/services.py
@@ -88,19 +88,15 @@ class CompletionService:
         Note: The nodes passed in should have already taken the user into
         account so the proper blocks are shown for this user.
         """
-        if XBlockCompletionMode.get_mode(node) == XBlockCompletionMode.EXCLUDED:
-            return []
-
         user_children = []
-        if XBlockCompletionMode.get_mode(node) == XBlockCompletionMode.AGGREGATOR:
+        mode = XBlockCompletionMode.get_mode(node)
+        if mode == XBlockCompletionMode.AGGREGATOR:
             node_children = ((hasattr(node, 'get_child_descriptors') and node.get_child_descriptors())
                              or (hasattr(node, 'get_children') and node.get_children()))
             for child in node_children:
                 user_children.extend(self.get_completable_children(child))
-
-        if XBlockCompletionMode.get_mode(node) == XBlockCompletionMode.COMPLETABLE:
+        elif mode == XBlockCompletionMode.COMPLETABLE:
             user_children = [node]
-
         return user_children
 
     def vertical_is_complete(self, item):

--- a/completion/services.py
+++ b/completion/services.py
@@ -95,7 +95,7 @@ class CompletionService:
                              or (hasattr(node, 'get_children') and node.get_children()))
             for child in node_children:
                 user_children.extend(self.get_completable_children(child))
-        elif mode == XBlockCompletionMode.COMPLETABLE:
+        elif node and mode == XBlockCompletionMode.COMPLETABLE:
             user_children = [node]
         return user_children
 


### PR DESCRIPTION
as there are cases where this comes back `None`.

Outstanding question: Instead of filtering out invalid children
after-the-fact, should we move this logic into the called function,
`self.get_completable_children` to prevent it from _ever_ returning a
`None`-child?

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
