### PR TITLE
[BD-21] Make use of edx_toggles newest API for testing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.2.5] - 2020-10-23
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Fix waffle switch override in tests by relying on newest edx_toggles API
+
 [3.2.4] - 2020-07-21
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Fix AttributeError raised by `vertical_is_complete`.

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '3.2.4'
+__version__ = '3.2.5'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/api/v1/views.py
+++ b/completion/api/v1/views.py
@@ -78,7 +78,7 @@ class CompletionBatchView(APIView):
             ObjectDoesNotExist:
                 If a database object cannot be found an ObjectDoesNotExist is raised.
         """
-        if not waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
+        if not waffle.ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled():
             raise ValidationError(
                 _("BlockCompletion.objects.submit_batch_completion should not be called when the feature is disabled.")
             )

--- a/completion/handlers.py
+++ b/completion/handlers.py
@@ -20,7 +20,7 @@ def scorable_block_completion(sender, **kwargs):  # pylint: disable=unused-argum
     """
     When a problem is scored, submit a new BlockCompletion for that block.
     """
-    if not waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
+    if not waffle.ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled():
         return
     try:
         block_key = UsageKey.from_string(kwargs['usage_id'])

--- a/completion/models.py
+++ b/completion/models.py
@@ -95,7 +95,7 @@ class BlockCompletionManager(models.Manager):
                 "block_key = block_key.replace(course_key=modulestore().fill_in_run(block_key.course_key))"
             )
 
-        if waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING):
+        if waffle.ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled():
             try:
                 with transaction.atomic():
                     obj, is_new = self.get_or_create(  # pylint: disable=unpacking-non-sequence

--- a/completion/services.py
+++ b/completion/services.py
@@ -35,7 +35,7 @@ class CompletionService:
 
             bool -> True if completion tracking is enabled.
         """
-        return waffle.waffle().is_enabled(waffle.ENABLE_COMPLETION_TRACKING)
+        return waffle.ENABLE_COMPLETION_TRACKING_SWITCH.is_enabled()
 
     def get_completions(self, candidates):
         """

--- a/completion/settings/common.py
+++ b/completion/settings/common.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'completion',
+    'waffle',
 )
 
 LOCALE_PATHS = [

--- a/completion/waffle.py
+++ b/completion/waffle.py
@@ -4,26 +4,30 @@ waffle switches for the completion app.
 """
 
 
-try:
-    from openedx.core.djangoapps.waffle_utils import WaffleSwitchNamespace
-except ImportError:
-    pass
+from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
 
 # Namespace
-WAFFLE_NAMESPACE = 'completion'
-
-# Switches
-
-# Full name: completion.enable_completion_tracking
-# Indicates whether or not to track completion of individual blocks.  Keeping
-# this disabled will prevent creation of BlockCompletion objects in the
-# database, as well as preventing completion-related network access by certain
-# xblocks.
-ENABLE_COMPLETION_TRACKING = 'enable_completion_tracking'
+WAFFLE_NAMESPACE = "completion"
 
 
 def waffle():
     """
     Returns the namespaced, cached, audited Waffle class for completion.
     """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix='completion: ')
+    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix="completion: ")
+
+
+# Switches
+
+# The switch name variable is preserved for backward compatibility
+ENABLE_COMPLETION_TRACKING = "enable_completion_tracking"
+# .. toggle_name: completion.enable_completion_tracking
+# .. toggle_implementation: WaffleSwitch
+# .. toggle_default: False
+# .. toggle_description: Indicates whether or not to track completion of individual blocks. Keeping this disabled
+#   will prevent creation of BlockCompletion objects in the database, as well as preventing completion-related
+#   network access by certain xblocks.
+# .. toggle_use_cases: open_edx
+ENABLE_COMPLETION_TRACKING_SWITCH = WaffleSwitch(
+    waffle(), ENABLE_COMPLETION_TRACKING, module_name=__name__
+)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,5 +6,6 @@ djangorestframework
 django-model-utils
 edx-opaque-keys[django]
 edx-drf-extensions>=1.11.0
+edx-toggles
 pytz
 XBlock>=1.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,23 +12,26 @@ certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
-click==7.1.2              # via click-log, edx-lint, pip-tools
+click==7.1.2              # via click-log, code-annotations, edx-lint, pip-tools
+code-annotations==0.10.0  # via edx-toggles
 coverage==5.3             # via pytest-cov
 cryptography==3.1         # via pyjwt
 ddt==1.4.1                # via -r requirements/test.in
 diff-cover==4.0.0         # via -r requirements/dev.in
 distlib==0.3.1            # via virtualenv
+django-crum==0.7.7        # via edx-toggles
 django-model-utils==4.0.0  # via -r requirements/base.in
-django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, rest-condition
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions, edx-toggles
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, code-annotations, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-i18n-tools, edx-opaque-keys, edx-toggles, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.in, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via readme-renderer
 drf-jwt==1.17.1           # via edx-drf-extensions
-edx-django-utils==3.8.0   # via edx-drf-extensions
+edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/quality.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
+edx-toggles==1.1.1        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv
@@ -42,7 +45,7 @@ inflect==3.0.2            # via -c requirements/constraints.txt, jinja2-pluraliz
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
-jinja2==2.11.2            # via diff-cover, jinja2-pluralize
+jinja2==2.11.2            # via code-annotations, diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via astroid
 lxml==4.5.2               # via xblock
 markupsafe==1.1.1         # via jinja2, xblock
@@ -78,8 +81,9 @@ pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==3.10.0     # via -r requirements/test.in
 pytest==6.0.2             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via edx-drf-extensions, faker, freezegun, xblock
+python-slugify==4.0.1     # via code-annotations
 pytz==2020.1              # via -r requirements/base.in, django, fs, xblock
-pyyaml==5.3.1             # via edx-i18n-tools, xblock
+pyyaml==5.3.1             # via code-annotations, edx-i18n-tools, xblock
 readme-renderer==26.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via edx-drf-extensions, pyjwkest, requests-toolbelt, twine
@@ -88,8 +92,8 @@ semantic-version==2.8.5   # via edx-drf-extensions
 six==1.15.0               # via astroid, bleach, cryptography, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, readme-renderer, stevedore, tox, virtualenv, xblock
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
-text-unidecode==1.3       # via faker
+stevedore==1.32.0         # via code-annotations, edx-django-utils, edx-opaque-keys
+text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.1              # via pytest, tox
 tox-battery==0.5.2        # via -c requirements/constraints.txt, -r requirements/dev.in
 tox==3.20.0               # via -r requirements/dev.in, tox-battery

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -11,20 +11,24 @@ babel==2.8.0              # via sphinx
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via doc8, requests
+click==7.1.2              # via code-annotations
+code-annotations==0.10.0  # via edx-toggles
 coverage==5.3             # via pytest-cov
 cryptography==3.1         # via pyjwt
 ddt==1.4.1                # via -r requirements/test.in
+django-crum==0.7.7        # via edx-toggles
 django-model-utils==4.0.0  # via -r requirements/base.in
-django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions, edx-toggles
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, code-annotations, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-toggles, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.in, drf-jwt, edx-drf-extensions, rest-condition
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, restructuredtext-lint, sphinx
 drf-jwt==1.17.1           # via edx-drf-extensions
-edx-django-utils==3.8.0   # via edx-drf-extensions
+edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+edx-toggles==1.1.1        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in
@@ -34,7 +38,7 @@ idna==2.10                # via requests
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.7.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
-jinja2==2.11.2            # via sphinx
+jinja2==2.11.2            # via code-annotations, sphinx
 lxml==4.5.2               # via xblock
 markupsafe==1.1.1         # via jinja2, xblock
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
@@ -57,8 +61,9 @@ pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==3.10.0     # via -r requirements/test.in
 pytest==6.0.2             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via edx-drf-extensions, faker, freezegun, xblock
+python-slugify==4.0.1     # via code-annotations
 pytz==2020.1              # via -r requirements/base.in, babel, django, fs, xblock
-pyyaml==5.3.1             # via xblock
+pyyaml==5.3.1             # via code-annotations, xblock
 requests==2.24.0          # via edx-drf-extensions, pyjwkest, sphinx
 rest-condition==1.0.3     # via edx-drf-extensions
 restructuredtext-lint==1.3.1  # via doc8
@@ -73,8 +78,8 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via doc8, edx-django-utils, edx-opaque-keys
-text-unidecode==1.3       # via faker
+stevedore==1.32.0         # via code-annotations, doc8, edx-django-utils, edx-opaque-keys
+text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.1              # via pytest
 typing==3.7.4.3           # via fs
 urllib3==1.25.10          # via requests

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,20 +12,23 @@ certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
 click-log==0.3.2          # via edx-lint
-click==7.1.2              # via click-log, edx-lint
+click==7.1.2              # via click-log, code-annotations, edx-lint
+code-annotations==0.10.0  # via edx-toggles
 coverage==5.3             # via pytest-cov
 cryptography==3.1         # via pyjwt
 ddt==1.4.1                # via -r requirements/test.in
+django-crum==0.7.7        # via edx-toggles
 django-model-utils==4.0.0  # via -r requirements/base.in
-django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, rest-condition
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions, edx-toggles
+django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, code-annotations, django-crum, django-model-utils, djangorestframework, drf-jwt, edx-django-utils, edx-drf-extensions, edx-opaque-keys, edx-toggles, rest-condition
 djangorestframework==3.11.1  # via -r requirements/base.in, drf-jwt, edx-drf-extensions, rest-condition
 docutils==0.16            # via readme-renderer
 drf-jwt==1.17.1           # via edx-drf-extensions
-edx-django-utils==3.8.0   # via edx-drf-extensions
+edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-lint==1.5.2           # via -r requirements/quality.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
+edx-toggles==1.1.1        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in
@@ -35,9 +38,10 @@ idna==2.10                # via requests
 importlib-metadata==1.7.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
+jinja2==2.11.2            # via code-annotations
 lazy-object-proxy==1.4.3  # via astroid
 lxml==4.5.2               # via xblock
-markupsafe==1.1.1         # via xblock
+markupsafe==1.1.1         # via jinja2, xblock
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.5.0     # via pytest
@@ -66,8 +70,9 @@ pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==3.10.0     # via -r requirements/test.in
 pytest==6.0.2             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via edx-drf-extensions, faker, freezegun, xblock
+python-slugify==4.0.1     # via code-annotations
 pytz==2020.1              # via -r requirements/base.in, django, fs, xblock
-pyyaml==5.3.1             # via xblock
+pyyaml==5.3.1             # via code-annotations, xblock
 readme-renderer==26.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.24.0          # via edx-drf-extensions, pyjwkest, requests-toolbelt, twine
@@ -76,8 +81,8 @@ semantic-version==2.8.5   # via edx-drf-extensions
 six==1.15.0               # via astroid, bleach, cryptography, edx-drf-extensions, edx-lint, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, stevedore, xblock
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
-text-unidecode==1.3       # via faker
+stevedore==1.32.0         # via code-annotations, edx-django-utils, edx-opaque-keys
+text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.1              # via pytest
 tqdm==4.49.0              # via twine
 twine==1.15.0             # via -c requirements/constraints.txt, -r requirements/quality.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,15 +9,19 @@ attrs==20.2.0             # via pytest
 certifi==2020.6.20        # via requests
 cffi==1.14.3              # via cryptography
 chardet==3.0.4            # via requests
+click==7.1.2              # via code-annotations
+code-annotations==0.10.0  # via edx-toggles
 coverage==5.3             # via pytest-cov
 cryptography==3.1         # via pyjwt
 ddt==1.4.1                # via -r requirements/test.in
+django-crum==0.7.7        # via edx-toggles
 django-model-utils==4.0.0  # via -r requirements/base.in
-django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions
+django-waffle==2.0.0      # via edx-django-utils, edx-drf-extensions, edx-toggles
 drf-jwt==1.17.1           # via edx-drf-extensions
-edx-django-utils==3.8.0   # via edx-drf-extensions
+edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
+edx-toggles==1.1.1        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in
@@ -26,8 +30,9 @@ future==0.18.2            # via pyjwkest
 idna==2.10                # via requests
 importlib-metadata==1.7.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
+jinja2==2.11.2            # via code-annotations
 lxml==4.5.2               # via xblock
-markupsafe==1.1.1         # via xblock
+markupsafe==1.1.1         # via jinja2, xblock
 mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/test.in
 more-itertools==8.5.0     # via pytest
 newrelic==5.18.0.148      # via edx-django-utils
@@ -47,15 +52,16 @@ pytest-cov==2.10.1        # via -r requirements/test.in
 pytest-django==3.10.0     # via -r requirements/test.in
 pytest==6.0.2             # via pytest-cov, pytest-django
 python-dateutil==2.8.1    # via edx-drf-extensions, faker, freezegun, xblock
+python-slugify==4.0.1     # via code-annotations
 pytz==2020.1              # via -r requirements/base.in, django, fs, xblock
-pyyaml==5.3.1             # via xblock
+pyyaml==5.3.1             # via code-annotations, xblock
 requests==2.24.0          # via edx-drf-extensions, pyjwkest
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
 six==1.15.0               # via cryptography, edx-drf-extensions, edx-opaque-keys, fs, mock, packaging, pathlib2, pyjwkest, python-dateutil, stevedore, xblock
 sqlparse==0.3.1           # via django
-stevedore==1.32.0         # via edx-django-utils, edx-opaque-keys
-text-unidecode==1.3       # via faker
+stevedore==1.32.0         # via code-annotations, edx-django-utils, edx-opaque-keys
+text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.1              # via pytest
 typing==3.7.4.3           # via fs
 urllib3==1.25.10          # via requests


### PR DESCRIPTION
**Description:** Make use of edx_toggles API for overriding waffle switches in tests

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943

**Dependencies:** https://github.com/edx/edx-toggles/pull/75 :heavy_check_mark: merged

**Reviewers:**
- [x] @robrap

**Merge checklist:**
- [x] All reviewers approved
- [x]  @robrap to confirm `deprecated_waffle_utils` custom attribute data exists before landing this
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
