### PR TITLE
[BD-21] Get rid of deprecated waffle namespace classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,8 +18,8 @@ Unreleased
 [4.0.0] - 2020-11-05
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Remove soon-to-be-deprecated WaffleSwitchNamespace class instances
-* BACKWARD INCOMPATIBLE: Removes ``waffle()``, which returned a (now deprecated) WaffleSwitchNamespace. This should only affect tests in edx-platform. 
-* Requires edx-toggles>=2.0.0, which introduces backward-incompatible changes to WaffleSwitch.
+* BACKWARD INCOMPATIBLE: Removes ``waffle()``, which returned a (now deprecated) WaffleSwitchNamespace. This should only affect tests in edx-platform.
+* Requires edx-toggles>=1.2.0, which introduces a new API to waffle objects.
 * Refactors ``ENABLE_COMPLETION_TRACKING_SWITCH`` from a ``LegacyWaffleSwitch`` to the updated ``WaffleSwitch``.  We don't expect uses of this updated switch to require changes, unless there are surprise uses of deprecated methods from ``LegacyWaffleSwitch``.
 
 [3.2.5] - 2020-10-23

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+
+[4.0.0] - 2020-11-05
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Remove soon-to-be-deprecated WaffleSwitchNamespace class instances
+* BACKWARD INCOMPATIBLE: Removes ``waffle()``, which returned a (now deprecated) WaffleSwitchNamespace. This should only affect tests in edx-platform. 
+* Requires edx-toggles>=2.0.0, which introduces backward-incompatible changes to WaffleSwitch.
+* Refactors ``ENABLE_COMPLETION_TRACKING_SWITCH`` from a ``LegacyWaffleSwitch`` to the updated ``WaffleSwitch``.  We don't expect uses of this updated switch to require changes, unless there are surprise uses of deprecated methods from ``LegacyWaffleSwitch``.
+
 [3.2.5] - 2020-10-23
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Fix waffle switch override in tests by relying on newest edx_toggles API

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '3.2.5'
+__version__ = '4.0.0'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/waffle.py
+++ b/completion/waffle.py
@@ -4,22 +4,10 @@ waffle switches for the completion app.
 """
 
 
-from edx_toggles.toggles import WaffleSwitch, WaffleSwitchNamespace
+from edx_toggles.toggles import WaffleSwitch
 
-# Namespace
+# The switch and namespace names variables are preserved for backward compatibility
 WAFFLE_NAMESPACE = "completion"
-
-
-def waffle():
-    """
-    Returns the namespaced, cached, audited Waffle class for completion.
-    """
-    return WaffleSwitchNamespace(name=WAFFLE_NAMESPACE, log_prefix="completion: ")
-
-
-# Switches
-
-# The switch name variable is preserved for backward compatibility
 ENABLE_COMPLETION_TRACKING = "enable_completion_tracking"
 # .. toggle_name: completion.enable_completion_tracking
 # .. toggle_implementation: WaffleSwitch
@@ -29,5 +17,6 @@ ENABLE_COMPLETION_TRACKING = "enable_completion_tracking"
 #   network access by certain xblocks.
 # .. toggle_use_cases: open_edx
 ENABLE_COMPLETION_TRACKING_SWITCH = WaffleSwitch(
-    waffle(), ENABLE_COMPLETION_TRACKING, module_name=__name__
+    "{}.{}".format(WAFFLE_NAMESPACE, ENABLE_COMPLETION_TRACKING),
+    module_name=__name__,
 )

--- a/completion/waffle.py
+++ b/completion/waffle.py
@@ -4,7 +4,7 @@ waffle switches for the completion app.
 """
 
 
-from edx_toggles.toggles import WaffleSwitch
+from edx_toggles.toggles.__future__ import WaffleSwitch
 
 # The switch and namespace names variables are preserved for backward compatibility
 WAFFLE_NAMESPACE = "completion"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,6 +6,6 @@ djangorestframework
 django-model-utils
 edx-opaque-keys[django]
 edx-drf-extensions>=1.11.0
-edx-toggles>=2.0.0
+edx-toggles>=1.2.0
 pytz
 XBlock>=1.2.2

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,6 +6,6 @@ djangorestframework
 django-model-utils
 edx-opaque-keys[django]
 edx-drf-extensions>=1.11.0
-edx-toggles
+edx-toggles>=2.0.0
 pytz
 XBlock>=1.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,7 +31,7 @@ edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/quality.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
-edx-toggles==1.1.1        # via -r requirements/base.in
+edx-toggles==2.0.0        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,7 +31,7 @@ edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
 edx-lint==1.5.2           # via -r requirements/dev.in, -r requirements/quality.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
-edx-toggles==2.0.0        # via -r requirements/base.in
+edx-toggles==1.2.0        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 filelock==3.0.12          # via tox, virtualenv

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -28,7 +28,7 @@ edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-edx-toggles==1.1.1        # via -r requirements/base.in
+edx-toggles==2.0.0        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -28,7 +28,7 @@ edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-edx-toggles==2.0.0        # via -r requirements/base.in
+edx-toggles==1.2.0        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -28,7 +28,7 @@ edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-lint==1.5.2           # via -r requirements/quality.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
-edx-toggles==1.1.1        # via -r requirements/base.in
+edx-toggles==2.0.0        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -28,7 +28,7 @@ edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-lint==1.5.2           # via -r requirements/quality.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
-edx-toggles==2.0.0        # via -r requirements/base.in
+edx-toggles==1.2.0        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,7 +21,7 @@ drf-jwt==1.17.1           # via edx-drf-extensions
 edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
-edx-toggles==1.1.1        # via -r requirements/base.in
+edx-toggles==2.0.0        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,7 +21,7 @@ drf-jwt==1.17.1           # via edx-drf-extensions
 edx-django-utils==3.8.0   # via edx-drf-extensions, edx-toggles
 edx-drf-extensions==6.1.2  # via -r requirements/base.in
 edx-opaque-keys[django]==2.1.1  # via -r requirements/base.in, edx-drf-extensions
-edx-toggles==2.0.0        # via -r requirements/base.in
+edx-toggles==1.2.0        # via -r requirements/base.in
 factory-boy==3.0.1        # via -r requirements/test.in
 faker==4.1.3              # via factory-boy
 freezegun==1.0.0          # via -r requirements/test.in


### PR DESCRIPTION
The WaffleSwitchNamespace class is going to be deprecated soon.
edx-platform needs this app to stop using the namespace class in order
to upgrade to the latest edx-toggles release.

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

**Reviewers:**
- [x] @robrap 

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)

Note that this will break unit tests in edx-platform.