### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
+[3.2.6] - 2020-11-19
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Updated the build status badge in README.rst to point to travis-ci.com instead of travis-ci.org
 
 [3.2.5] - 2020-10-23
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -89,8 +89,8 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/edx-completion/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.org/edx/completion.svg?branch=master
-    :target: https://travis-ci.org/edx/completion
+.. |travis-badge| image:: https://travis-ci.com/edx/completion.svg?branch=master
+    :target: https://travis-ci.com/edx/completion
     :alt: Travis
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/completion/coverage.svg?branch=master

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '3.2.5'
+__version__ = '3.2.6'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089