### PR TITLE
Fix reference to deprecated student.models import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,11 @@ Change Log
 
 Unreleased
 ~~~~~~~~~~
-[3.2.6] - 2020-11-19
+
+[4.0.1] - 2021-01-05
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Replace reference to deprecated import path ``student.models``
+  with ``common.djangoapps.student.models``.
 * Updated the build status badge in README.rst to point to travis-ci.com instead of travis-ci.org
 
 

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/api/v1/views.py
+++ b/completion/api/v1/views.py
@@ -28,7 +28,7 @@ from opaque_keys.edx.keys import LearningContextKey, UsageKey
 from opaque_keys import InvalidKeyError
 
 try:
-    from student.models import CourseEnrollment
+    from common.djangoapps.student.models import CourseEnrollment
     from lms.djangoapps.course_api.blocks.api import get_blocks
     from openedx.core.lib.api.authentication import BearerAuthenticationAllowInactiveUser
 except ImportError:


### PR DESCRIPTION
The import path:
   `student.models`
is deprecated in favor of:
   `common.djangoapps.student.models`.

There should be no functional change.

Bump version from 4.0.0 to 4.0.1.

Related to https://github.com/edx/edx-platform/pull/25932