### PR TITLE
[BD-21] Upgrade usage of edx_toggles.toggles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.0.2] - 2021-02-04
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Future-proof usage of ``edx_toggles.toggles``
+
+
 [4.0.1] - 2021-01-05
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Replace reference to deprecated import path ``student.models``

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '4.0.1'
+__version__ = '4.0.2'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/waffle.py
+++ b/completion/waffle.py
@@ -4,7 +4,7 @@ waffle switches for the completion app.
 """
 
 
-from edx_toggles.toggles.__future__ import WaffleSwitch
+from edx_toggles.toggles import WaffleSwitch
 
 # The switch and namespace names variables are preserved for backward compatibility
 WAFFLE_NAMESPACE = "completion"


### PR DESCRIPTION
**Description:** The waffle classes previously in __future__ are now available directly from
edx_toggles.toggles. Since this `__future__` module is going to be removed soon, we become future-proof by getting rid of it.

**JIRA:** https://openedx.atlassian.net/wiki/spaces/COMM/pages/1596358943/BD-21+Toggles+Settings+Documentation

**Reviewers:**
- [ ] @robrap 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Version bumped
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
