### PR TITLE
fix: make sure last completed block key includes course run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.0.4]- 2021-02-04
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Update ``get_key_to_last_completed_block`` to return ``full_block_key`` instead of ``block_key``
+
 [4.0.2] - 2021-02-04
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Future-proof usage of ``edx_toggles.toggles``

--- a/completion/__init__.py
+++ b/completion/__init__.py
@@ -2,6 +2,6 @@
 Completion App
 """
 
-__version__ = '4.0.3'
+__version__ = '4.0.4'
 
 default_app_config = 'completion.apps.CompletionAppConfig'  # pylint: disable=invalid-name

--- a/completion/utilities.py
+++ b/completion/utilities.py
@@ -25,6 +25,6 @@ def get_key_to_last_completed_block(user, context_key):
     last_completed_block = BlockCompletion.get_latest_block_completed(user, context_key)
 
     if last_completed_block is not None:
-        return last_completed_block.block_key
+        return last_completed_block.full_block_key
 
     raise UnavailableCompletionData(context_key)


### PR DESCRIPTION
**Description:** This makes sure we always use the full block key that includes the course run when calling this utility function.

**Related PR:** https://github.com/edx/edx-platform/pull/27046

**Reviewers:**
- [ ] tag reviewer 
- [ ] tag reviewer 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is 
      finished.
- [ ] Delete working branch (if not needed anymore)
