### PR TITLE
chore: updated CI badge to point to GitHub Actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 completion
 =============================
 
-|pypi-badge| |travis-badge| |codecov-badge| |doc-badge| |pyversions-badge|
+|pypi-badge| |CI| |codecov-badge| |doc-badge| |pyversions-badge|
 |license-badge|
 
 A library for tracking completion of blocks by learners in edX courses.
@@ -89,9 +89,9 @@ refer to this `list of resources`_ if you need any assistance.
     :target: https://pypi.python.org/pypi/edx-completion/
     :alt: PyPI
 
-.. |travis-badge| image:: https://travis-ci.com/edx/completion.svg?branch=master
-    :target: https://travis-ci.com/edx/completion
-    :alt: Travis
+.. |CI| image:: https://github.com/edx/completion/workflows/Python%20CI/badge.svg?branch=master
+    :target: https://github.com/edx/completion/actions?query=workflow%3A%22Python+CI%22
+    :alt: CI
 
 .. |codecov-badge| image:: http://codecov.io/github/edx/completion/coverage.svg?branch=master
     :target: http://codecov.io/github/edx/completion?branch=master


### PR DESCRIPTION
Updated CI badge to point to GitHub Actions instead of Travis 

JIRA: https://openedx.atlassian.net/browse/BOM-2728