### PR TITLE
fix: use branch name directly

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,7 +8,7 @@ on:
        branch:
          description: 'Target branch to create requirements PR against'
          required: true
-         default: $default-branch
+         default: 'master'
 jobs:
    call-upgrade-python-requirements-workflow:
     with:


### PR DESCRIPTION
$default-branch is only available in workflow-templates so we'll use branch name directly in this workflow

https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable